### PR TITLE
Add auth headers to api-server calls

### DIFF
--- a/client/init-puavo.d/90-puavo-setup-puavo-config
+++ b/client/init-puavo.d/90-puavo-setup-puavo-config
@@ -10,6 +10,7 @@ if [ -n "$SERVER" -a -e /etc/puavo/domain ]; then
   # set --max-time to 30 seconds to allow the boot to continue in case of
   # failure; so we can check out later (with ssh or some such) what went wrong.
   if curl --cacert /etc/puavo/certs/rootca.pem \
+          --header "Authorization: Bootserver" \
           --fail \
           --max-time 30 \
           --silent \

--- a/client/ltsp_config.d/02-find-puavo-ltsp-server
+++ b/client/ltsp_config.d/02-find-puavo-ltsp-server
@@ -11,6 +11,7 @@ case "$(cat /etc/puavo/hosttype)" in
       if [ -n "$API_SERVER" ]; then
         POSSIBLE_LDM_SERVER=$(
           curl --cacert /etc/puavo/certs/rootca.pem \
+               --header "Authorization: Bootserver" \
 	       --fail \
                --max-time 12 \
                "https://${API_SERVER}/v3/ltsp_servers/_most_idle" 2>/dev/null \

--- a/puavo-install/puavo-update-laptop
+++ b/puavo-install/puavo-update-laptop
@@ -20,6 +20,7 @@ puavo_rest_request() {
 
   puavo_rest_server=$(puavo-resolve-api-server) || return
   curl --cacert /etc/puavo/certs/rootca.pem \
+       --header "Authorization: Bootserver" \
        --fail \
        --max-time 60 \
        --silent \


### PR DESCRIPTION
In future 'Authorization: Bootserver' header is required to access rest
resources without any other credentials.

https://github.com/opinsys/puavo-users/commit/a6daac536e87172389a32a385395dd17f709924d
