### PR TITLE
Diskinstaller2

### DIFF
--- a/client/init-puavo.d/05-puavo-local-partitions
+++ b/client/init-puavo.d/05-puavo-local-partitions
@@ -59,9 +59,11 @@ puavo_link_to_state() {
 }
 
 puavo_mount_partition() {
-  name=$1
-  if [ -b "/dev/mapper/puavo-$name" ]; then
-    mkdir -p /$name
+  puavo_partition=$1
+  puavo_mntpoint=$2
+
+  if [ -b "/dev/mapper/${puavo_partition}" ]; then
+    mkdir -p "$puavo_mntpoint"
 
     OPTIONS="-o noatime"
 
@@ -71,33 +73,39 @@ puavo_mount_partition() {
       fi
     fi
 
-    mount $OPTIONS /dev/mapper/puavo-$name /$name
+    mount $OPTIONS "/dev/mapper/${puavo_partition}" "$puavo_mntpoint"
   fi
 }
 
 if [ -x "/sbin/vgchange" ]; then
-  vgchange -a y puavo
+  case "$PUAVO_HOSTTYPE" in
+    installer) vgchange -a y puavoinstaller ;;
+    *)         vgchange -a y puavo          ;;
+  esac
 
   case "$PUAVO_HOSTTYPE" in
     fatclient)
       if [ -b "/dev/mapper/puavo-tmp" ]; then
-        puavo_mount_partition tmp
+        puavo_mount_partition puavo-tmp /tmp
         chmod 1777 /tmp
       fi
       ;;
+    installer)
+      puavo_mount_partition puavoinstaller-installimages /installimages
+      ;;
     laptop)
-      puavo_mount_partition home
-      puavo_mount_partition images
+      puavo_mount_partition puavo-home   /home
+      puavo_mount_partition puavo-images /images
       ;;
     wirelessaccesspoint)
-      puavo_mount_partition images
+      puavo_mount_partition puavo-images /images
       ;;
   esac
 
   case "$PUAVO_HOSTTYPE" in
     laptop|ltspserver|wirelessaccesspoint)
       if [ -b "/dev/mapper/puavo-state" ]; then
-	puavo_mount_partition state
+	puavo_mount_partition puavo-state /state
 
 	# must fix in case puavo gid has changed...
 	chgrp puavo /state/etc/puavo/ldap/password
@@ -132,7 +140,7 @@ if [ -x "/sbin/vgchange" ]; then
       fi
 
       if [ -b "/dev/mapper/puavo-tmp" ]; then
-        puavo_mount_partition tmp
+        puavo_mount_partition puavo-tmp /tmp
         chmod 1777 /tmp
       fi
       ;;

--- a/client/ltsp_config.d/00-puavoltsp-by-hosttype
+++ b/client/ltsp_config.d/00-puavoltsp-by-hosttype
@@ -222,13 +222,22 @@ case "$PUAVO_HOSTTYPE" in
     set_lts_var SSH_OVERRIDE_PORT    222
     set_lts_var X_COLOR_DEPTH        16
     ;;
-  unregistered)
+  unregistered|installer)
+    if [ "$PUAVO_HOSTTYPE" = "installer" ]; then
+      # we are booting from an installer pseudo-hosttype
+      # so we need network-manager
+      puavo_unregistered_unneeded_session_services=""
+    else
+      puavo_unregistered_unneeded_session_services="network-manager"
+    fi
+
     set_lts_var RM_SESSION_SERVICES "
       nm-applet
       puavo-client-updater-applet
     "
     set_lts_var RM_SYSTEM_SERVICES "
       $puavo_common_unneeded_services
+      $puavo_unregistered_unneeded_session_services
       cron
       eno
       fluentd

--- a/client/ltsp_config.d/00-puavoltsp-by-hosttype
+++ b/client/ltsp_config.d/00-puavoltsp-by-hosttype
@@ -246,7 +246,6 @@ case "$PUAVO_HOSTTYPE" in
       lightdm
       ltspguestssh
       ltspssh
-      network-manager
       nscd
       nslcd
       ntp

--- a/client/screen.d/register
+++ b/client/screen.d/register
@@ -26,3 +26,5 @@ done
 
 echo
 reboot
+
+sleep 600

--- a/debian.default/control
+++ b/debian.default/control
@@ -53,7 +53,7 @@ Package: puavo-ltsp-install
 Architecture: all
 Depends: ${misc:Depends}, ruby-highline, nbd-client, pv, rdiff, curl,
  puavo-client, ruby-dbus, python-gtk2, python-appindicator, python-dbus,
- expect-dev, python-notify, wget, jq
+ expect-dev, python-notify, wget, jq, m4
 Description: Bits and pieces needed inside the LTSP chroot image.
 
 Package: puavo-image-tools

--- a/puavo-install/Makefile
+++ b/puavo-install/Makefile
@@ -49,6 +49,7 @@ install : installdirs
 		puavo-install \
 		puavo-install-and-update-ltspimages \
 		puavo-install-grub \
+		puavo-make-install-disk \
 		puavo-setup-filesystems \
 		puavo-update-client
 

--- a/puavo-install/lib/update-configuration
+++ b/puavo-install/lib/update-configuration
@@ -61,15 +61,23 @@ update_wlan_configurations() {
         /state/etc/puavo/wlan.json
 }
 
-update_kernel_version_and_arguments() {
+update_grub_environment() {
   kernel_version=$(  jq -r .kernel_version   /state/etc/puavo/device.json)
   kernel_arguments=$(jq -r .kernel_arguments /state/etc/puavo/device.json)
+  personally_administered=$(jq -r .personally_administered \
+				  /state/etc/puavo/device.json)
 
   if [ -n "$kernel_version" -a "$kernel_version" != "null" ]; then
     grub-editenv /images/boot/grub/grubenv set \
                  "puavo_kernel_version=$kernel_version"
   else
     grub-editenv /images/boot/grub/grubenv unset puavo_kernel_version
+  fi
+
+  if [ "$personally_administered" = "true" ]; then
+    grub-editenv /images/boot/grub/grubenv set "puavo_show_imageoverlays=true"
+  else
+    grub-editenv /images/boot/grub/grubenv unset puavo_show_imageoverlays
   fi
 
   if [ -n "$kernel_arguments" -a "$kernel_arguments" != "null" ]; then
@@ -84,8 +92,8 @@ update_kernel_version_and_arguments() {
 # try to update others (order does not matter here, but do this sequentially
 # anyway).
 
-update_ltsconf                      || true
-update_device_json                  || true
-update_external_files               || true
-update_wlan_configurations          || true
-update_kernel_version_and_arguments || true
+update_ltsconf             || true
+update_device_json         || true
+update_external_files      || true
+update_wlan_configurations || true
+update_grub_environment    || true

--- a/puavo-install/puavo-install
+++ b/puavo-install/puavo-install
@@ -58,6 +58,16 @@ preseed_count=$(echo "${preseeds}" | wc -l)
     break
 done
 
+# This might be "unregistered" or "installer" (which is unregistered in a
+# different way), so we read this now and use later.
+previous_hosttype="$(cat /etc/puavo/hosttype)"
+
+if ! [    "$previous_hosttype" = 'unregistered' \
+       -o "$previous_hosttype" = 'installer' ]; then
+  echo "'$previous_hosttype' is not a supported hosttype for installation" >&2
+  exit 1
+fi
+
 puavo-register \
     --accepted-devicetypes fatclient,laptop,ltspserver,thinclient,wirelessaccesspoint \
     ${puavo_register_args}
@@ -81,8 +91,18 @@ case "$hosttype" in
     # install from nbd, the ltsp image must contain its name in this path
     ltspimage_name=$(cat /etc/ltsp/this_ltspimage_name)
 
-    puavo-install-and-update-ltspimages --install-from-nbd /dev/nbd0 \
-					"$ltspimage_name"
+    case "$previous_hosttype" in
+      installer)
+        puavo-install-and-update-ltspimages                      \
+          --install-from-file "/installimages/${ltspimage_name}" \
+          "$ltspimage_name"
+        ;;
+      *)
+        puavo-install-and-update-ltspimages --install-from-nbd /dev/nbd0 \
+					    "$ltspimage_name"
+        ;;
+    esac
+
 
     echo "Updating $hosttype configuration..."
     if /usr/lib/puavo-ltsp-install/update-configuration; then

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -37,7 +37,7 @@ usage() {
 }
 
 if ! args=$(getopt -n "$0" -o +f:n:r:q \
-		   -l 'install-from-file:,install-from-nbd:,rate-limit:,quiet,delete-overlays' \
+		   -l 'install-from-file:,install-from-nbd:,rate-limit:,quiet,delete-overlays,images-dir:,no-preinst-hook' \
 		   -- "$@"); then
   usage
 fi
@@ -50,12 +50,19 @@ image_from_nbd=""
 rate_limit_opts=""
 quiet=false
 delete_overlays=false
+run_preinst_hook=true
 
 eval "set -- $args"
 while [ $# -ne 0 ]; do
   case "$1" in
     --delete-overlays)
       delete_overlays=true; shift
+      ;;
+    --images-dir)
+      images_dir="$2"; shift; shift
+      ;;
+    --no-preinst-hook)
+      run_preinst_hook=false; shift
       ;;
     -f|--install-from-file)
       image_from_file="$2"; shift; shift
@@ -573,6 +580,10 @@ EOF
 }
 
 run_image_preinst_hook() {
+  if ! $run_preinst_hook; then
+    return 0
+  fi
+
   imagename=$1
   imagepath="${images_dir}/${imagename}"
 

--- a/puavo-install/puavo-install-grub
+++ b/puavo-install/puavo-install-grub
@@ -81,13 +81,12 @@ function ltsp_image_entry_superlaptop {
   set description="$2"
   set kernelparameters="$3"
 
-  if [ ! -d (lvm/puavo-imageoverlays) ]; then
-    return
+  if test "${puavo_show_imageoverlays}" = "true" \
+            -a -d (lvm/puavo-imageoverlays); then
+    set kernelparameters="puavo.image.overlay=default puavo.local.enable_superusers=true $kernelparameters"
+
+    ltsp_image_entry "${imagefile}" "${description}" "${kernelparameters}"
   fi
-
-  set kernelparameters="puavo.image.overlay=default puavo.local.enable_superusers=true $kernelparameters"
-
-  ltsp_image_entry "${imagefile}" "${description}" "${kernelparameters}"
 }
 
 insmod gzio

--- a/puavo-install/puavo-install-grub
+++ b/puavo-install/puavo-install-grub
@@ -186,6 +186,12 @@ case "$hosttype" in
     ;;
 esac
 
+if [ "$hosttype" = 'installer' ]; then
+  puavo_lvm_partition='lvm/puavoinstaller-installimages'
+else
+  puavo_lvm_partition='lvm/puavo-images'
+fi
+
 if ! $only_update_config; then
   grub-install --root-directory=$images_dir "$diskdev"
 fi
@@ -195,7 +201,7 @@ tmp_grub_cfg_path="${grub_cfg_path}.tmp"
 
 grub_m4_template                                              \
   | m4 -D__PUAVO_KERNEL_ARGUMENTS__="$puavo_kernel_arguments" \
-       -D__PUAVO_LVM_PARTITION__="lvm/puavo-images"           \
+       -D__PUAVO_LVM_PARTITION__="$puavo_lvm_partition"       \
   > "$tmp_grub_cfg_path"
 
 windows_partition_number=$(lookup_windows_partition_number "$diskdev")

--- a/puavo-install/puavo-install-grub
+++ b/puavo-install/puavo-install-grub
@@ -68,7 +68,7 @@ function ltsp_image_entry {
 
     set kernelparameters="$4"
 
-    linux   /boot/vmlinuz${kernelversion} ro quiet splash init=/sbin/init-puavo __PUAVO_KERNEL_ARGUMENTS__ ${kernelparameters}
+    linux   /boot/vmlinuz${kernelversion} ro init=/sbin/init-puavo __PUAVO_KERNEL_ARGUMENTS__ ${kernelparameters}
     initrd  /boot/initrd.img${kernelversion}
 
     loopback -d loop
@@ -100,7 +100,7 @@ insmod loopback
 insmod usb_keyboard
 insmod lvm
 
-for dev in (__PUAVO_LVM_PARTITION__); do
+for dev in (lvm/__PUAVO_LVM_PARTITION__); do
   for file in ${dev}/*.default; do
     regexp -s default_alias_no_suffix '^(.*)\.default$' "${file}"
     break
@@ -176,21 +176,26 @@ else
   hosttype=$(cat /etc/puavo/hosttype)
 fi
 
+if [ "$hosttype" = 'installer' ]; then
+  puavo_lvm_partition='puavoinstaller-installimages'
+else
+  puavo_lvm_partition='puavo-images'
+fi
+
+common_kernel_arguments="puavo.hosttype=${hosttype} root=/dev/mapper/${puavo_lvm_partition} loop=\"\${imagepath}\""
+
 case "$hosttype" in
-  installer|laptop|wirelessaccesspoint)
-    puavo_kernel_arguments="puavo.hosttype=${hosttype} root=/dev/mapper/puavo-images loop=\"\${imagepath}\""
+  installer)
+    puavo_kernel_arguments="$common_kernel_arguments"
+    ;;
+  laptop|wirelessaccesspoint)
+    puavo_kernel_arguments="quiet splash ${common_kernel_arguments}"
     ;;
   *)
     echo "Hosttype '$hosttype' is not supported" > /dev/stderr
     exit 1
     ;;
 esac
-
-if [ "$hosttype" = 'installer' ]; then
-  puavo_lvm_partition='lvm/puavoinstaller-installimages'
-else
-  puavo_lvm_partition='lvm/puavo-images'
-fi
 
 if ! $only_update_config; then
   grub-install --root-directory=$images_dir "$diskdev"

--- a/puavo-install/puavo-install-grub
+++ b/puavo-install/puavo-install-grub
@@ -2,62 +2,6 @@
 
 set -e
 
-lookup_windows_partition_number() {
-  # Presume that the first partition not containing "Linux"
-  # is a Windows-partition.
-  _diskdev=$1
-  env LANG=C fdisk -l "$_diskdev" \
-    | awk '$1 ~ "^/dev/" && !/(Extended|Linux)/ {
-	     if (match($1, /[0-9]+$/, _)) { print _[0]; exit }
-           }'
-}
-
-if [ "$1" = "--only-update-config" ]; then
-  only_update_config=true
-  shift
-else
-  only_update_config=false
-fi
-
-images_dir=${1:-/images}
-vgname=${2:-puavo}
-
-if [ ! -d "$images_dir" ]; then
-  echo "'$images_dir' is not a directory" >&2
-  exit 1
-fi
-
-diskdev=$(pvs | awk -v vgname="$vgname" '$2 == vgname { print $1; exit }' \
-              | sed -E 's|[0-9]+$||')
-
-if [ -z "$diskdev" ]; then
-  echo "Could not find the disk device where volume group '${vgname}' is" >&2
-  exit 1
-fi
-
-if [ "$vgname" = 'puavoinstaller' ]; then
-  hosttype=installer
-else
-  hosttype=$(cat /etc/puavo/hosttype)
-fi
-
-case "$hosttype" in
-  installer|laptop|wirelessaccesspoint)
-    puavo_kernel_arguments="puavo.hosttype=${hosttype} root=/dev/mapper/puavo-images loop=\"\${imagepath}\""
-    ;;
-  *)
-    echo "Hosttype '$hosttype' is not supported" > /dev/stderr
-    exit 1
-    ;;
-esac
-
-if ! $only_update_config; then
-  grub-install --root-directory=$images_dir "$diskdev"
-fi
-
-grub_cfg_path="${images_dir}/boot/grub/grub.cfg"
-tmp_grub_cfg_path="${grub_cfg_path}.tmp"
-
 grub_m4_template() {
   cat <<'EOF'
 set default="0"
@@ -192,6 +136,62 @@ for dev in (__PUAVO_LVM_PARTITION__); do
 done
 EOF
 }
+
+lookup_windows_partition_number() {
+  # Presume that the first partition not containing "Linux"
+  # is a Windows-partition.
+  _diskdev=$1
+  env LANG=C fdisk -l "$_diskdev" \
+    | awk '$1 ~ "^/dev/" && !/(Extended|Linux)/ {
+	     if (match($1, /[0-9]+$/, _)) { print _[0]; exit }
+           }'
+}
+
+if [ "$1" = "--only-update-config" ]; then
+  only_update_config=true
+  shift
+else
+  only_update_config=false
+fi
+
+images_dir=${1:-/images}
+vgname=${2:-puavo}
+
+if [ ! -d "$images_dir" ]; then
+  echo "'$images_dir' is not a directory" >&2
+  exit 1
+fi
+
+diskdev=$(pvs | awk -v vgname="$vgname" '$2 == vgname { print $1; exit }' \
+              | sed -E 's|[0-9]+$||')
+
+if [ -z "$diskdev" ]; then
+  echo "Could not find the disk device where volume group '${vgname}' is" >&2
+  exit 1
+fi
+
+if [ "$vgname" = 'puavoinstaller' ]; then
+  hosttype=installer
+else
+  hosttype=$(cat /etc/puavo/hosttype)
+fi
+
+case "$hosttype" in
+  installer|laptop|wirelessaccesspoint)
+    puavo_kernel_arguments="puavo.hosttype=${hosttype} root=/dev/mapper/puavo-images loop=\"\${imagepath}\""
+    ;;
+  *)
+    echo "Hosttype '$hosttype' is not supported" > /dev/stderr
+    exit 1
+    ;;
+esac
+
+if ! $only_update_config; then
+  grub-install --root-directory=$images_dir "$diskdev"
+fi
+
+grub_cfg_path="${images_dir}/boot/grub/grub.cfg"
+tmp_grub_cfg_path="${grub_cfg_path}.tmp"
 
 grub_m4_template                                              \
   | m4 -D__PUAVO_KERNEL_ARGUMENTS__="$puavo_kernel_arguments" \

--- a/puavo-install/puavo-install-grub
+++ b/puavo-install/puavo-install-grub
@@ -20,23 +20,29 @@ else
 fi
 
 images_dir=${1:-/images}
-diskdev=$2
+vgname=${2:-puavo}
 
-if [ -z "$diskdev" ]; then
-  diskdev=$(pvs | awk '$2 == "puavo" { print $1; exit }' \
-		| sed -E 's|[0-9]+$||')
-fi
-
-if [ -z "$images_dir" -o -z "$diskdev" ]; then
-  echo "Usage: $(basename $0) [--only-update-config] [images_dir] [diskdev]" \
-    > /dev/stderr
+if [ ! -d "$images_dir" ]; then
+  echo "'$images_dir' is not a directory" >&2
   exit 1
 fi
 
-hosttype=$(cat /etc/puavo/hosttype)
+diskdev=$(pvs | awk -v vgname="$vgname" '$2 == vgname { print $1; exit }' \
+              | sed -E 's|[0-9]+$||')
+
+if [ -z "$diskdev" ]; then
+  echo "Could not find the disk device where volume group '${vgname}' is" >&2
+  exit 1
+fi
+
+if [ "$vgname" = 'puavoinstaller' ]; then
+  hosttype=installer
+else
+  hosttype=$(cat /etc/puavo/hosttype)
+fi
 
 case "$hosttype" in
-  laptop|wirelessaccesspoint)
+  installer|laptop|wirelessaccesspoint)
     hosttype_specific="puavo.hosttype=${hosttype} root=/dev/mapper/puavo-images loop=\"\${imagepath}\""
     ;;
   *)

--- a/puavo-install/puavo-install-grub
+++ b/puavo-install/puavo-install-grub
@@ -43,7 +43,7 @@ fi
 
 case "$hosttype" in
   installer|laptop|wirelessaccesspoint)
-    hosttype_specific="puavo.hosttype=${hosttype} root=/dev/mapper/puavo-images loop=\"\${imagepath}\""
+    puavo_kernel_arguments="puavo.hosttype=${hosttype} root=/dev/mapper/puavo-images loop=\"\${imagepath}\""
     ;;
   *)
     echo "Hosttype '$hosttype' is not supported" > /dev/stderr
@@ -58,7 +58,8 @@ fi
 grub_cfg_path="${images_dir}/boot/grub/grub.cfg"
 tmp_grub_cfg_path="${grub_cfg_path}.tmp"
 
-cat <<'EOF' | sed "s|__HOSTTYPE_SPECIFIC__|$hosttype_specific|" > "$tmp_grub_cfg_path"
+grub_m4_template() {
+  cat <<'EOF'
 set default="0"
 load_env
 
@@ -123,7 +124,7 @@ function ltsp_image_entry {
 
     set kernelparameters="$4"
 
-    linux   /boot/vmlinuz${kernelversion} ro quiet splash init=/sbin/init-puavo __HOSTTYPE_SPECIFIC__ ${kernelparameters}
+    linux   /boot/vmlinuz${kernelversion} ro quiet splash init=/sbin/init-puavo __PUAVO_KERNEL_ARGUMENTS__ ${kernelparameters}
     initrd  /boot/initrd.img${kernelversion}
 
     loopback -d loop
@@ -155,7 +156,7 @@ insmod loopback
 insmod usb_keyboard
 insmod lvm
 
-for dev in (lvm/puavo-images); do
+for dev in (__PUAVO_LVM_PARTITION__); do
   for file in ${dev}/*.default; do
     regexp -s default_alias_no_suffix '^(.*)\.default$' "${file}"
     break
@@ -190,6 +191,12 @@ for dev in (lvm/puavo-images); do
   done
 done
 EOF
+}
+
+grub_m4_template                                              \
+  | m4 -D__PUAVO_KERNEL_ARGUMENTS__="$puavo_kernel_arguments" \
+       -D__PUAVO_LVM_PARTITION__="lvm/puavo-images"           \
+  > "$tmp_grub_cfg_path"
 
 windows_partition_number=$(lookup_windows_partition_number "$diskdev")
 

--- a/puavo-install/puavo-make-install-disk
+++ b/puavo-install/puavo-make-install-disk
@@ -32,3 +32,5 @@ esac
 puavo-install-grub "$images_dir" puavoinstaller
 
 umount "$images_dir"
+dmsetup remove puavoinstaller-installimages
+vgchange -a n puavoinstaller

--- a/puavo-install/puavo-make-install-disk
+++ b/puavo-install/puavo-make-install-disk
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -eu
+
+images_dir=/installimages
+ltspimage_name=$(cat /etc/ltsp/this_ltspimage_name)
+
+install_image() {
+  puavo-install-and-update-ltspimages --images-dir "$images_dir" \
+                                      --no-preinst-hook          \
+                                      "$@"                       \
+                                      "$ltspimage_name"
+}
+
+puavo-setup-filesystems --setup-for-installer
+
+puavo_hosttype=$(cat /etc/puavo/hosttype)
+
+case "$puavo_hosttype" in
+  fatclient|ltspserver|thinclient)
+    install_image --install-from-nbd /dev/nbd0
+    ;;
+  laptop|wirelessaccesspoint)
+    install_image --install-from-file "/images/${ltspimage_name}"
+    ;;
+  *)
+    echo 'Cannot create an install disk on this hosttype' >&2
+    exit 1
+    ;;
+esac
+
+puavo-install-grub "$images_dir" puavoinstaller

--- a/puavo-install/puavo-make-install-disk
+++ b/puavo-install/puavo-make-install-disk
@@ -34,3 +34,4 @@ puavo-install-grub "$images_dir" puavoinstaller
 umount "$images_dir"
 dmsetup remove puavoinstaller-installimages
 vgchange -a n puavoinstaller
+rmdir /installimages

--- a/puavo-install/puavo-make-install-disk
+++ b/puavo-install/puavo-make-install-disk
@@ -30,3 +30,5 @@ case "$puavo_hosttype" in
 esac
 
 puavo-install-grub "$images_dir" puavoinstaller
+
+umount "$images_dir"

--- a/puavo-install/puavo-setup-filesystems
+++ b/puavo-install/puavo-setup-filesystems
@@ -68,14 +68,28 @@ module DiskHandler
       run('umount', '-f', "/#{ name }") rescue true
     end
 
-    # If we are creating an installer, we do not want to mess with the
-    # running system in any way.
     if hosttype != 'installer' then
-      # turn off swap partitions
+      # Turn off swap partitions from the target device (and possibly some
+      # else...).  If our target hosttype is "installer", we do not need to
+      # do this because installer disks should not contain (active) swap
+      # partitions (and turning swap off from the current host is not
+      # appropriate).  (The really proper solution should disable swap
+      # selectively from the disk we are installing to.)
       run('swapoff', '-a') rescue true
+    end
 
-      # Remove dmsetup volumes as well, in case these are effective.
-      run('dmsetup', 'remove_all', '--force') rescue true
+    dm_device_list = \
+      case hosttype
+        when 'installer'
+          %w(puavoinstaller-installimages)
+        else
+          (Filesystems[hosttype] || []) \
+            .keys.map { |partname| "puavo-#{ partname }" }
+      end
+
+    # remove all dmsetup volumes which may exists on the target host
+    dm_device_list.each do |dm_device|
+      run('dmsetup', 'remove', '--force', dm_device) rescue true
     end
 
     # switch off all volume groups that may interfere with following operations
@@ -448,7 +462,7 @@ end
 UI::parse_args
 
 hosttype = UI::setup_for_installer \
-             ? 'installer'    \
+             ? 'installer'         \
              : PuavoFacts::get('puavo_hosttype')
 
 vgname = (hosttype == 'installer') ? 'puavoinstaller' : 'puavo'

--- a/puavo-install/puavo-setup-filesystems
+++ b/puavo-install/puavo-setup-filesystems
@@ -83,8 +83,9 @@ module DiskHandler
         when 'installer'
           %w(puavoinstaller-installimages)
         else
-          (Filesystems[hosttype] || []) \
-            .keys.map { |partname| "puavo-#{ partname }" }
+          %w(swap0) \
+            + ((Filesystems[hosttype] || {}) \
+                .keys.map { |partname| "puavo-#{ partname }" })
       end
 
     # remove all dmsetup volumes which may exists on the target host

--- a/puavo-install/puavo-setup-filesystems
+++ b/puavo-install/puavo-setup-filesystems
@@ -37,6 +37,9 @@ end
 
 module DiskHandler
   Filesystems = {
+    'installer' => {
+      'installimages' => { 'size' => '100%FREE', 'type' => 'ext4' },
+    },
     'laptop' => {
       'swap'          => { 'size' => '4G',       'type' => 'swap' },
       'tmp'           => { 'size' => '6G',       'type' => 'ext4' },
@@ -59,23 +62,27 @@ module DiskHandler
     },
   }
 
-  def self.cleanup_disk_environment(hosttype)
+  def self.cleanup_disk_environment(hosttype, vgname)
     # Unmount filesystems, if those are mounted.
     non_swap_filesystems(hosttype).each do |name, attrs|
       run('umount', '-f', "/#{ name }") rescue true
     end
 
-    # turn off swap partitions
-    run('swapoff', '-a') rescue true
+    # If we are creating an installer, we do not want to mess with the
+    # running system in any way.
+    if hosttype != 'installer' then
+      # turn off swap partitions
+      run('swapoff', '-a') rescue true
 
-    # Remove dmsetup volumes as well, in case these are effective.
-    run('dmsetup', 'remove_all', '--force') rescue true
+      # Remove dmsetup volumes as well, in case these are effective.
+      run('dmsetup', 'remove_all', '--force') rescue true
+    end
 
     # switch off all volume groups that may interfere with following operations
-    run('vgchange', '-a', 'n') rescue true
+    run('vgchange', '-a', 'n', vgname) rescue true
   end
 
-  def self.do_fs_setup(conf)
+  def self.do_fs_setup(conf, vgname)
     fs_conf = conf.clone
 
     fs_setup_phases = []
@@ -93,7 +100,10 @@ module DiskHandler
 		     'partition' => "/dev/#{ fs_conf['partition'] }" })
 
     fs_setup_phases.each do |fn_sym|
-      method(fn_sym).call(fs_conf)
+      args = [ :mount_filesystems, :puavo_filesystems ].include?(fn_sym) \
+                ? [ fs_conf, vgname ]                                    \
+                : [ fs_conf         ]
+      method(fn_sym).call(*args)
     end
   end
 
@@ -117,38 +127,38 @@ module DiskHandler
       .select { |name, attrs| attrs['type'] != 'swap' }
   end
 
-  def self.puavo_filesystems(fs_conf)
+  def self.puavo_filesystems(fs_conf, vgname)
     # clean up possible confusing mess from the partition
     run('dd', 'if=/dev/zero', "of=#{ fs_conf['partition'] }", 'count=1K')
 
     # create LVM volume groups
     run('pvcreate', fs_conf['partition'])
-    run('vgcreate', '-s', '64M', 'puavo', fs_conf['partition'])
+    run('vgcreate', '-s', '64M', vgname, fs_conf['partition'])
 
     Filesystems[ fs_conf['hosttype'] ].each do |name, attrs|
-      mkfs(attrs['size'], name, attrs['type'])
+      mkfs(attrs['size'], name, attrs['type'], vgname)
     end
   end
 
-  def self.mkfs(size, name, type)
+  def self.mkfs(size, name, type, vgname)
     run('lvcreate',
 	(size.match(/%/) ? '-l' : '-L'), size,
 	'-n', name,
-	'puavo')
+	vgname)
 
     case type
       when 'ext4'
-        run('mkfs.ext4', '-v', "/dev/mapper/puavo-#{ name }")
+        run('mkfs.ext4', '-v', "/dev/mapper/#{ vgname }-#{ name }")
       when 'swap'
-        run('mkswap',    '-f', "/dev/mapper/puavo-#{ name }")
+        run('mkswap',    '-f', "/dev/mapper/#{ vgname }-#{ name }")
     end
   end
 
-  def self.mount_filesystems(fs_conf)
+  def self.mount_filesystems(fs_conf, vgname)
     non_swap_filesystems( fs_conf['hosttype'] ).each do |name, attrs|
       mnt_path = "/#{ name }"
       FileUtils.mkdir_p(mnt_path)
-      run('mount', "/dev/mapper/puavo-#{ name }", mnt_path)
+      run('mount', "/dev/mapper/#{ vgname }-#{ name }", mnt_path)
     end
   end
 end
@@ -341,6 +351,9 @@ module UI
 
   @accept_defaults = false
   @defaults = {}
+  @setup_for_installer = false
+
+  def self.setup_for_installer; @setup_for_installer end
 
   def self.help_and_exit
     puts <<-EOF
@@ -368,6 +381,7 @@ EOF
                             [ '--default-imageoverlay-size'  , GetoptLong::REQUIRED_ARGUMENT,],
                             [ '--default-partition'          , GetoptLong::REQUIRED_ARGUMENT,],
                             [ '--default-unpartitioned-space', GetoptLong::REQUIRED_ARGUMENT,],
+                            [ '--setup-for-installer'        , GetoptLong::NO_ARGUMENT      ,],
                             )
 
       opts.each do |opt, arg|
@@ -387,6 +401,8 @@ EOF
           @defaults[PartitionPrompt] = arg
         when '--default-unpartitioned-space'
           @defaults[UnpartitionedSpacePrompt] = arg
+        when '--setup-for-installer'
+          @setup_for_installer = true
         end
       end
     rescue GetoptLong::InvalidOption => e
@@ -431,14 +447,18 @@ end
 
 UI::parse_args
 
-hosttype = PuavoFacts::get('puavo_hosttype')
+hosttype = UI::setup_for_installer \
+             ? 'installer'    \
+             : PuavoFacts::get('puavo_hosttype')
 
-DiskHandler::cleanup_disk_environment(hosttype)
+vgname = (hosttype == 'installer') ? 'puavoinstaller' : 'puavo'
+
+DiskHandler::cleanup_disk_environment(hosttype, vgname)
 
 case hosttype
-  when 'laptop', 'ltspserver', 'wirelessaccesspoint'
+  when 'installer', 'laptop', 'ltspserver', 'wirelessaccesspoint'
     conf = QueryDiskInfo::ask_device_and_partition_with_confirmation(hosttype)
-    DiskHandler::do_fs_setup(conf)
+    DiskHandler::do_fs_setup(conf, vgname)
   else
     puts "Hosttype '#{ hosttype }' does not need to setup local filesystems."
 end


### PR DESCRIPTION
A feature that makes it possible to install devices without network. Mainly intended for laptops without PXE capability, but all types of devices (not bootservers) should work. A machine should be booted from an installation disk such as a usb-memorystick and then can be installed.

See ticket https://github.com/opinsys/puavo/issues/71.