### PR TITLE
client: Add tag use_puavo_printer_permissions that forces use of

### DIFF
--- a/client/etc/X11/Xsession.d/90puavo-setup-printers
+++ b/client/etc/X11/Xsession.d/90puavo-setup-printers
@@ -61,6 +61,12 @@ case "${hosttype}" in
         set_default_printer
         ;;
     *)
-        echo "hosttype '${hosttype}' does not support Puavo printer setup" >&2
+        if jq -r .tags[] /etc/puavo/device.json | grep -qx use_puavo_printer_permissions; then
+            remove_remote_printers
+            add_remote_printers
+            set_default_printer
+        else
+            echo "hosttype '${hosttype}' does not support Puavo printer setup" >&2
+        fi
         ;;
 esac


### PR DESCRIPTION
client: Add tag use_puavo_printer_permissions that forces use of
printer permissions from Puavo even when they would not normally
be used. Useful e.g. on laptop installations that always stay in
the same network and are more like local workstations than roaming
mobile devices.