### PR TITLE
Updates for DNS-SD printer information queries

### DIFF
--- a/client/etc/NetworkManager/dispatcher.d/dnssd-printers
+++ b/client/etc/NetworkManager/dispatcher.d/dnssd-printers
@@ -7,6 +7,6 @@ if [ "${COMMAND}" = "up" ]; then
   PUAVO_HOSTTYPE=$(cat /etc/puavo/hosttype)
 
   if [ "${PUAVO_HOSTTYPE}" = "laptop" ]; then
-    /usr/sbin/puavo-dnssd-printer-client --delay 5 >/dev/null 2>&1 &
+    /usr/sbin/puavo-dnssd-printer-client --retries 6 --retry-delay 15 --delay 5 >/dev/null 2>&1 &
   fi
 fi

--- a/client/etc/NetworkManager/dispatcher.d/dnssd-printers
+++ b/client/etc/NetworkManager/dispatcher.d/dnssd-printers
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-PUAVO_HOSTTYPE=$(cat /etc/puavo/hosttype)
+IFACE=$1
+COMMAND=$2
 
-if [ "${PUAVO_HOSTTYPE}" = "laptop" ]; then
-  /usr/sbin/puavo-dnssd-printer-client --delay 5 >/dev/null 2>&1 &
+if [ "${COMMAND}" = "up" ]; then
+  PUAVO_HOSTTYPE=$(cat /etc/puavo/hosttype)
+
+  if [ "${PUAVO_HOSTTYPE}" = "laptop" ]; then
+    /usr/sbin/puavo-dnssd-printer-client --delay 5 >/dev/null 2>&1 &
+  fi
 fi

--- a/client/etc/NetworkManager/dispatcher.d/dnssd-printers
+++ b/client/etc/NetworkManager/dispatcher.d/dnssd-printers
@@ -7,6 +7,6 @@ if [ "${COMMAND}" = "up" ]; then
   PUAVO_HOSTTYPE=$(cat /etc/puavo/hosttype)
 
   if [ "${PUAVO_HOSTTYPE}" = "laptop" ]; then
-    /usr/sbin/puavo-dnssd-printer-client --retries 6 --retry-delay 15 --delay 5 >/dev/null 2>&1 &
+    /usr/sbin/puavo-dnssd-printer-client --retries 6 --retry-delay 15 --delay 10 >/dev/null 2>&1 &
   fi
 fi

--- a/client/puavo-dnssd-printer-client
+++ b/client/puavo-dnssd-printer-client
@@ -101,21 +101,21 @@ def query_printer(printer, ipps=false)
     res.each_resource(printer, 'TXT') { |rr|
       rr.rdata.each do |data|
         if /rp=(.*)/.match(data)
-          path = $1
+          path = $1.tr('^A-Za-z0-9\-_/', '')
         end
 
         if /note=(.*)/.match(data)
-          name = $1
+          name = $1.tr('^A-Za-z0-9\-_\.', '')
         end
 
         if /URF=(.*)/.match(data)
-          urf = $1
+          urf = $1.tr('^A-Za-z0-9\-_', '')
         end
       end
     }
 
     res.each_resource(printer, 'SRV') { |rr|
-      server = rr.target.to_s
+      server = rr.target.to_s.tr('^A-Za-z0-9\-_.', '')
     }
 
     if ipps

--- a/client/puavo-dnssd-printer-client
+++ b/client/puavo-dnssd-printer-client
@@ -35,6 +35,10 @@ This keeps printer lists stable e.g. when network connection is flaky.
 If the --delete-unmanaged option is specified, all unmanaged printers 
 are deleted always (even when --require-dns-records is defined).
 
+Normally DNS is queried once, but the number of retries can be set with 
+--retries=X option. The delay between retries is by default 15 seconds, but 
+it can be changed with --retry-delay=XX option.
+
 =end
 
 require 'etc'
@@ -178,10 +182,23 @@ opts = Trollop::options do
   opt :delete_unmanaged, "Delete unmanaged printers"
   opt :no_dns_query, "Do not query DNS records"
   opt :require_dns_records, "Require DNS records to exist before doing updates"
+  opt :retries, "Retry number of times if DNS query fails", :type => Integer
+  opt :retry_delay, "Delay between retries (default 15 seconds)", :type => Integer
 end
 
 if opts[:delay]
   sleep(opts[:delay])
+end
+
+retries = 1
+retry_delay = 15
+
+if opts[:retries]
+  retries = opts[:retries]
+end
+
+if opts[:retry_delay]
+  retry_delay = opts[:retry_delay]
 end
 
 dname = "b._dns-sd._udp"
@@ -216,24 +233,32 @@ printers = Hash.new
 ptr_records_ok = false
 
 if !opts[:no_dns_query]
-  begin
-    res   = Dnsruby::DNS.new
+  while retries > 0 and !ptr_records_ok
+    retries = retries-1
 
-    res.each_resource(dname, 'PTR') { |rr|
-      begin
-        printers.merge! query_domain(rr.rdata, false)
-        ptr_records_ok = true
-      rescue DNSException => e
-      end
+    begin
+      res   = Dnsruby::DNS.new
 
-      begin
-        printers.merge! query_domain(rr.rdata, true)
-        ptr_records_ok = true
-      rescue DNSException => e
-      end
-    }
-  rescue Exception => e
-    print "Can't find PTR records for #{dname}: ", e, "\n"
+      res.each_resource(dname, 'PTR') { |rr|
+        begin
+          printers.merge! query_domain(rr.rdata, false)
+          ptr_records_ok = true
+        rescue DNSException => e
+        end
+
+        begin
+          printers.merge! query_domain(rr.rdata, true)
+          ptr_records_ok = true
+        rescue DNSException => e
+        end
+      }
+    rescue Exception => e
+      print "Can't find PTR records for #{dname}: ", e, "\n"
+     end
+
+    if retries > 0 and !ptr_records_ok
+      sleep(retry_delay)
+    end
   end
 
   if opts[:require_dns_records] and !ptr_records_ok

--- a/client/puavo-dnssd-printer-client
+++ b/client/puavo-dnssd-printer-client
@@ -39,6 +39,9 @@ Normally DNS is queried once, but the number of retries can be set with
 --retries=X option. The delay between retries is by default 15 seconds, but 
 it can be changed with --retry-delay=XX option.
 
+With --continuous and --continuous-delay, the script can be set to run 
+in indefinite loop instead of running just once.
+
 =end
 
 require 'etc'
@@ -184,6 +187,8 @@ opts = Trollop::options do
   opt :require_dns_records, "Require DNS records to exist before doing updates"
   opt :retries, "Retry number of times if DNS query fails", :type => Integer
   opt :retry_delay, "Delay between retries (default 15 seconds)", :type => Integer
+  opt :continuous, "Run continuously instead of just running once"
+  opt :continuous_delay, "Delay between runs in continuous mode (default 300 seconds)", :type => Integer
 end
 
 if opts[:delay]
@@ -192,6 +197,7 @@ end
 
 retries = 1
 retry_delay = 15
+continuous_delay = 300
 
 if opts[:retries]
   retries = opts[:retries]
@@ -201,108 +207,122 @@ if opts[:retry_delay]
   retry_delay = opts[:retry_delay]
 end
 
+if opts[:continuous_delay]
+  continuous_delay = opts[:continuous_delay]
+end
+
 dname = "b._dns-sd._udp"
 
-# First read old printer list
+begin
 
-managed_printers = Hash.new
+  # First read old printer list
 
-if File.exists?("/var/lib/puavo-desktop/dnssd_printers")
-  json = JSON.parse(File.read("/var/lib/puavo-desktop/dnssd_printers"))
+  managed_printers = Hash.new
 
-  json.each do |o|
-    printer = Printer.json_create(o)
-    managed_printers[printer.name] = printer
-  end
-end
+  if File.exists?("/var/lib/puavo-desktop/dnssd_printers")
+    json = JSON.parse(File.read("/var/lib/puavo-desktop/dnssd_printers"))
 
-# Get list of printers currently configured in CUPS
-
-current_printers = Hash.new
-
-`lpstat -v 2>/dev/null`.split("\n").each do |line|
-  if /device for (.*?): (.*)/.match(line)
-    name = $1
-    ipp = $2
-
-    current_printers[$1] = Printer.new(name, ipp, "", "")
-  end
-end
-
-printers = Hash.new
-ptr_records_ok = false
-
-if !opts[:no_dns_query]
-  while retries > 0 and !ptr_records_ok
-    retries = retries-1
-
-    begin
-      res   = Dnsruby::DNS.new
-
-      res.each_resource(dname, 'PTR') { |rr|
-        begin
-          printers.merge! query_domain(rr.rdata, false)
-          ptr_records_ok = true
-        rescue DNSException => e
-        end
-
-        begin
-          printers.merge! query_domain(rr.rdata, true)
-          ptr_records_ok = true
-        rescue DNSException => e
-        end
-      }
-    rescue Exception => e
-      print "Can't find PTR records for #{dname}: ", e, "\n"
-     end
-
-    if retries > 0 and !ptr_records_ok
-      sleep(retry_delay)
+    json.each do |o|
+      printer = Printer.json_create(o)
+      managed_printers[printer.name] = printer
     end
   end
 
-  if opts[:require_dns_records] and !ptr_records_ok
-    log "--require-dns-records defined and DNS entries were not found, not updating records"
-  else
-    # Delete printers that are not available anymore
+  # Get list of printers currently configured in CUPS
 
-    old_printers = managed_printers.select do |name, printer|
-      if !printers.has_key?(name) or !printers[name].equals?(printer)
-        log "Delete old printer entry #{printer.name} #{printer.path}"
-        delete_printer(printer)
+  current_printers = Hash.new
+
+  `lpstat -v 2>/dev/null`.split("\n").each do |line|
+    if /device for (.*?): (.*)/.match(line)
+      name = $1
+      ipp = $2
+
+      current_printers[$1] = Printer.new(name, ipp, "", "")
+    end
+  end
+
+  printers = Hash.new
+  ptr_records_ok = false
+
+  if !opts[:no_dns_query]
+    retry_counter = 0
+
+    while retry_counter < retries and !ptr_records_ok
+      retry_counter += 1
+
+      begin
+        res   = Dnsruby::DNS.new
+
+        res.each_resource(dname, 'PTR') { |rr|
+          begin
+            printers.merge! query_domain(rr.rdata, false)
+            ptr_records_ok = true
+          rescue DNSException => e
+          end
+
+          begin
+            printers.merge! query_domain(rr.rdata, true)
+            ptr_records_ok = true
+          rescue DNSException => e
+          end
+        }
+      rescue Exception => e
+        print "Can't find PTR records for #{dname}: ", e, "\n"
+      end
+
+      if retry_counter < retries and !ptr_records_ok
+        sleep(retry_delay)
       end
     end
 
-    # Add new entries
+    if opts[:require_dns_records] and !ptr_records_ok
+      log "--require-dns-records defined and DNS entries were not found, not updating records"
+    else
+      # Delete printers that are not available anymore
 
-    new_printers = printers.select do |name, printer|
-      if !current_printers.has_key?(name) or (!current_printers[name].equals?(printer))
-        log "Add new printer entry #{printer.name} #{printer.path}"
+      old_printers = managed_printers.select do |name, printer|
+        if !printers.has_key?(name) or !printers[name].equals?(printer)
+          log "Delete old printer entry #{printer.name} #{printer.path}"
+          delete_printer(printer)
+        end
+      end
+
+      # Add new entries
+
+      new_printers = printers.select do |name, printer|
+        if !current_printers.has_key?(name) or (!current_printers[name].equals?(printer))
+          log "Add new printer entry #{printer.name} #{printer.path}"
  
-        add_printer(printer)
+          add_printer(printer)
+        end
+      end
+
+      # Write new list of managed entries to the disk
+
+      File.open("/var/lib/puavo-desktop/dnssd_printers", "w") do |file|
+        file.puts printers.values.to_json
+      end
+
+      managed_printers = printers
+    end
+  end
+
+  # Finally delete all unmanaged entries if that was requested
+
+  if opts[:delete_unmanaged]
+    `lpstat -a 2>/dev/null`.split("\n").each do |line|
+      name = line.split(" ")[0]
+
+      if !managed_printers.has_key?(name)
+        log "Deleting unmanaged printer #{name}"
+
+        delete_printer(Printer.new(name, "", "", ""))
       end
     end
-
-    # Write new list of managed entries to the disk
-
-    File.open("/var/lib/puavo-desktop/dnssd_printers", "w") do |file|
-      file.puts printers.values.to_json
-    end
-
-    managed_printers = printers
   end
-end
 
-# Finally delete all unmanaged entries if that was requested
-
-if opts[:delete_unmanaged]
-  `lpstat -a 2>/dev/null`.split("\n").each do |line|
-    name = line.split(" ")[0]
-
-    if !managed_printers.has_key?(name)
-      log "Deleting unmanaged printer #{name}"
-
-      delete_printer(Printer.new(name, "", "", ""))
-    end
+  if opts[:continuous]
+    sleep(continuous_delay)
   end
-end
+
+end while opts[:continuous]

--- a/client/puavo-dnssd-printer-client
+++ b/client/puavo-dnssd-printer-client
@@ -173,11 +173,11 @@ def query_domain(domain, ipps)
 end
 
 def add_printer(printer)
-  `lpadmin -p "#{printer.name}" -E -v #{printer.path} -L "#{printer.location}" -D "#{printer.description}"`
+  `/usr/sbin/lpadmin -p "#{printer.name}" -E -v #{printer.path} -L "#{printer.location}" -D "#{printer.description}"`
 end
 
 def delete_printer(printer)
-  `lpadmin -x #{printer.name}`
+  `/usr/sbin/lpadmin -x #{printer.name}`
 end
 
 opts = Trollop::options do
@@ -325,4 +325,7 @@ begin
     sleep(continuous_delay)
   end
 
+rescue Exception => e
+  log "Error: #{e} - exiting"
+  exit(1)
 end while opts[:continuous]


### PR DESCRIPTION
It seems like some laptops do not get their network setup fast enough, so the printer update script run too fast which results in failed queries. The queries are delayed a bit more and new retry options make the script also try the queries multiple times.