### PR TITLE
Imageupdaterchanges

### DIFF
--- a/client/etc/X11/Xsession.d/41puavo-set-locale
+++ b/client/etc/X11/Xsession.d/41puavo-set-locale
@@ -52,6 +52,7 @@ else
     de) LANG=de_DE.UTF-8 ;;
     en) LANG=en_GB.UTF-8 ;;
     fi) LANG=fi_FI.UTF-8 ;;
+    fr) LANG=fr_FR.UTF-8 ;;
     sv) LANG=sv_FI.UTF-8 ;;
      *)
         echo "unknown language '${puavo_language_short_form}', falling back to 'fi'" >&2

--- a/client/etc/network/if-up.d/sssd
+++ b/client/etc/network/if-up.d/sssd
@@ -4,13 +4,19 @@
 test "$IFACE" != lo || exit 0
 
 PUAVO_HOSTTYPE=$(cat /etc/puavo/hosttype)
+PUAVO_DOMAIN=$(cat /etc/puavo/domain)
 
 if [ "$PUAVO_HOSTTYPE" != "laptop" ]; then
   exit 0
 fi
 
-# Make sure that sssd goes online
-sleep 1
-killall -USR2 sssd
-sleep 6
-killall -USR2 sssd
+# Make sure that sssd goes online when we are in network matching the 
+# puavo domain. Otherwise sssd takes some time before realising that 
+# there's a kerberos server available.
+
+case $DHCP4_DOMAIN_NAME in *${PUAVO_DOMAIN})
+  sleep 1
+  killall -USR2 sssd
+  sleep 6
+  killall -USR2 sssd
+esac

--- a/client/init-puavo.d/91-puavo-setup-locale
+++ b/client/init-puavo.d/91-puavo-setup-locale
@@ -14,6 +14,7 @@ puavo_preferred_language=$(jq -r .preferred_language /etc/puavo/device.json)
       de) echo "LANG=de_DE.UTF-8" ;;
       fi) echo "LANG=fi_FI.UTF-8" ;;
       en) echo "LANG=en_GB.UTF-8" ;;
+      fr) echo "LANG=fr_FR.UTF-8" ;;
       sv) echo "LANG=sv_FI.UTF-8" ;;
        *)
           echo "unknown language '${puavo_language_short_form}', falling back to 'fi'" >&2

--- a/client/puavo-ltsp-login
+++ b/client/puavo-ltsp-login
@@ -89,6 +89,7 @@ class DesktopSettings
       'de' => 'de_DE.UTF-8',
       'en' => 'en_GB.UTF-8',
       'fi' => 'fi_FI.UTF-8',
+      'fr' => 'fr_FR.UTF-8',
       'ru' => 'ru_RU.UTF-8',
       'sv' => 'sv_FI.UTF-8',
     }

--- a/puavo-install/lib/update-configuration
+++ b/puavo-install/lib/update-configuration
@@ -49,12 +49,6 @@ update_external_files() {
     puavo-handle-external-files-actions
 }
 
-update_ltsconf() {
-    install -o root -g root -m 600 /dev/null /state/etc/lts.conf.tmp || return
-    puavo-lts > /state/etc/lts.conf.tmp                              || return
-    replace_if_changed /state/etc/lts.conf /state/etc/lts.conf.tmp
-}
-
 update_wlan_configurations() {
     wlan_networks_uri="v3/devices/$(cat /etc/puavo/hostname)/wlan_networks"
     puavo_rest_request_and_replace "$wlan_networks_uri" \
@@ -92,7 +86,6 @@ update_grub_environment() {
 # try to update others (order does not matter here, but do this sequentially
 # anyway).
 
-update_ltsconf             || true
 update_device_json         || true
 update_external_files      || true
 update_wlan_configurations || true

--- a/puavo-install/po/fi/puavo-client-updater-applet.po
+++ b/puavo-install/po/fi/puavo-client-updater-applet.po
@@ -63,31 +63,31 @@ msgstr "Päivitys keskeytetty."
 msgid "Up to date."
 msgstr "Päivitetty."
 
-#: puavo-client-updater-applet:259
+#: puavo-client-updater-applet:264
 msgid "Update progress:"
 msgstr "Päivityksen edistyminen:"
 
-#: puavo-client-updater-applet:279
+#: puavo-client-updater-applet:284
 msgid "System update has been started."
 msgstr "Järjestelmän päivitys on käynnistetty."
 
-#: puavo-client-updater-applet:292
+#: puavo-client-updater-applet:297
 msgid "Check for updates"
 msgstr "Tarkista päivitettävyys"
 
-#: puavo-client-updater-applet:295
+#: puavo-client-updater-applet:300
 msgid "(Checking for updates.)"
 msgstr "(Tarkistetaan päivitettävyyttä.)"
 
-#: puavo-client-updater-applet:299
+#: puavo-client-updater-applet:304
 msgid "Update"
 msgstr "Päivitä"
 
-#: puavo-client-updater-applet:302
+#: puavo-client-updater-applet:307
 msgid "Cancel update"
 msgstr "Peruuta päivitys"
 
-#: puavo-client-updater-applet:321
+#: puavo-client-updater-applet:326
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -95,10 +95,10 @@ msgstr ""
 "Vanha versio järjestelmästä sisältää käyttäjän tekemiä muutoksia, jotka "
 "tuhoutuvat päivityksessä. Haluatko jatkaa?"
 
-#: puavo-client-updater-applet:333
+#: puavo-client-updater-applet:338
 msgid "Continue updating?"
 msgstr "Jatka päivittämistä?"
 
-#: puavo-client-updater-applet:338
+#: puavo-client-updater-applet:343
 msgid "Update log"
 msgstr "Päivitysloki"

--- a/puavo-install/po/fi/puavo-client-updater-applet.po
+++ b/puavo-install/po/fi/puavo-client-updater-applet.po
@@ -23,19 +23,19 @@ msgstr "(Ei päivityksen edistymistä.)"
 msgid "View log..."
 msgstr "Näytä loki..."
 
-#: puavo-client-updater-applet:171
+#: puavo-client-updater-applet:175
 msgid "A new system update is available."
 msgstr "Järjestelmän voi päivittää uuteen."
 
-#: puavo-client-updater-applet:179
+#: puavo-client-updater-applet:183
 msgid "Update cancelled."
 msgstr "Päivitys peruutettu."
 
-#: puavo-client-updater-applet:183
+#: puavo-client-updater-applet:185
 msgid "System update has been cancelled."
 msgstr "Järjestelmän päivitys on peruutettu."
 
-#: puavo-client-updater-applet:191
+#: puavo-client-updater-applet:193
 msgid "Update completed."
 msgstr "Päivitys on valmis."
 
@@ -43,51 +43,51 @@ msgstr "Päivitys on valmis."
 msgid "System update is finished, reboot the computer."
 msgstr "Järjestelmän päivitys on tehty, uudelleenkäynnistä tietokone."
 
-#: puavo-client-updater-applet:205 puavo-client-updater-applet:228
+#: puavo-client-updater-applet:205 puavo-client-updater-applet:231
 msgid "Update failed."
 msgstr "Päivitys epäonnistui."
 
-#: puavo-client-updater-applet:209
+#: puavo-client-updater-applet:207
 msgid "An error occurred when updating the system."
 msgstr "Virhe tapahtui päivitettäessä järjestelmää."
 
-#: puavo-client-updater-applet:231
+#: puavo-client-updater-applet:234
 msgid "Update done, reboot required to finish the update."
 msgstr "Päivitys tehty, käyttöönotto vaatii uudelleenkäynnistyksen."
 
-#: puavo-client-updater-applet:234
+#: puavo-client-updater-applet:237
 msgid "Update interrupted."
 msgstr "Päivitys keskeytetty."
 
-#: puavo-client-updater-applet:237
+#: puavo-client-updater-applet:240
 msgid "Up to date."
 msgstr "Päivitetty."
 
-#: puavo-client-updater-applet:264
+#: puavo-client-updater-applet:267
 msgid "Update progress:"
 msgstr "Päivityksen edistyminen:"
 
-#: puavo-client-updater-applet:284
+#: puavo-client-updater-applet:287
 msgid "System update has been started."
 msgstr "Järjestelmän päivitys on käynnistetty."
 
-#: puavo-client-updater-applet:297
+#: puavo-client-updater-applet:300
 msgid "Check for updates"
 msgstr "Tarkista päivitettävyys"
 
-#: puavo-client-updater-applet:300
+#: puavo-client-updater-applet:303
 msgid "(Checking for updates.)"
 msgstr "(Tarkistetaan päivitettävyyttä.)"
 
-#: puavo-client-updater-applet:304
+#: puavo-client-updater-applet:307
 msgid "Update"
 msgstr "Päivitä"
 
-#: puavo-client-updater-applet:307
+#: puavo-client-updater-applet:310
 msgid "Cancel update"
 msgstr "Peruuta päivitys"
 
-#: puavo-client-updater-applet:326
+#: puavo-client-updater-applet:329
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -95,10 +95,10 @@ msgstr ""
 "Vanha versio järjestelmästä sisältää käyttäjän tekemiä muutoksia, jotka "
 "tuhoutuvat päivityksessä. Haluatko jatkaa?"
 
-#: puavo-client-updater-applet:338
+#: puavo-client-updater-applet:341
 msgid "Continue updating?"
 msgstr "Jatka päivittämistä?"
 
-#: puavo-client-updater-applet:343
+#: puavo-client-updater-applet:346
 msgid "Update log"
 msgstr "Päivitysloki"

--- a/puavo-install/po/fi/puavo-client-updater-applet.po
+++ b/puavo-install/po/fi/puavo-client-updater-applet.po
@@ -23,71 +23,71 @@ msgstr "(Ei päivityksen edistymistä.)"
 msgid "View log..."
 msgstr "Näytä loki..."
 
-#: puavo-client-updater-applet:181
+#: puavo-client-updater-applet:181 puavo-client-updater-applet:183
 msgid "A new system update is available."
 msgstr "Järjestelmän voi päivittää uuteen."
 
-#: puavo-client-updater-applet:189
+#: puavo-client-updater-applet:191
 msgid "Update cancelled."
 msgstr "Päivitys peruutettu."
 
-#: puavo-client-updater-applet:191
+#: puavo-client-updater-applet:193
 msgid "System update has been cancelled."
 msgstr "Järjestelmän päivitys on peruutettu."
 
-#: puavo-client-updater-applet:199
+#: puavo-client-updater-applet:201
 msgid "Update completed."
 msgstr "Päivitys on valmis."
 
-#: puavo-client-updater-applet:202
+#: puavo-client-updater-applet:204
 msgid "System update is finished, reboot the computer."
 msgstr "Järjestelmän päivitys on tehty, uudelleenkäynnistä tietokone."
 
-#: puavo-client-updater-applet:211 puavo-client-updater-applet:237
+#: puavo-client-updater-applet:213 puavo-client-updater-applet:242
 msgid "Update failed."
 msgstr "Päivitys epäonnistui."
 
-#: puavo-client-updater-applet:213
+#: puavo-client-updater-applet:215
 msgid "An error occurred when updating the system."
 msgstr "Virhe tapahtui päivitettäessä järjestelmää."
 
-#: puavo-client-updater-applet:240
+#: puavo-client-updater-applet:245
 msgid "Update done, reboot required to finish the update."
 msgstr "Päivitys tehty, käyttöönotto vaatii uudelleenkäynnistyksen."
 
-#: puavo-client-updater-applet:243
+#: puavo-client-updater-applet:248
 msgid "Update interrupted."
 msgstr "Päivitys keskeytetty."
 
-#: puavo-client-updater-applet:246
+#: puavo-client-updater-applet:251
 msgid "Up to date."
 msgstr "Päivitetty."
 
-#: puavo-client-updater-applet:273
+#: puavo-client-updater-applet:278
 msgid "Update progress:"
 msgstr "Päivityksen edistyminen:"
 
-#: puavo-client-updater-applet:293
+#: puavo-client-updater-applet:298 puavo-client-updater-applet:301
 msgid "System update has been started."
 msgstr "Järjestelmän päivitys on käynnistetty."
 
-#: puavo-client-updater-applet:306
+#: puavo-client-updater-applet:314
 msgid "Check for updates"
 msgstr "Tarkista päivitettävyys"
 
-#: puavo-client-updater-applet:309
+#: puavo-client-updater-applet:317
 msgid "(Checking for updates.)"
 msgstr "(Tarkistetaan päivitettävyyttä.)"
 
-#: puavo-client-updater-applet:313
+#: puavo-client-updater-applet:321
 msgid "Update"
 msgstr "Päivitä"
 
-#: puavo-client-updater-applet:316
+#: puavo-client-updater-applet:324
 msgid "Cancel update"
 msgstr "Peruuta päivitys"
 
-#: puavo-client-updater-applet:335
+#: puavo-client-updater-applet:343
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -95,10 +95,10 @@ msgstr ""
 "Vanha versio järjestelmästä sisältää käyttäjän tekemiä muutoksia, jotka "
 "tuhoutuvat päivityksessä. Haluatko jatkaa?"
 
-#: puavo-client-updater-applet:347
+#: puavo-client-updater-applet:355
 msgid "Continue updating?"
 msgstr "Jatka päivittämistä?"
 
-#: puavo-client-updater-applet:352
+#: puavo-client-updater-applet:360
 msgid "Update log"
 msgstr "Päivitysloki"

--- a/puavo-install/po/fi/puavo-client-updater-applet.po
+++ b/puavo-install/po/fi/puavo-client-updater-applet.po
@@ -23,71 +23,71 @@ msgstr "(Ei päivityksen edistymistä.)"
 msgid "View log..."
 msgstr "Näytä loki..."
 
-#: puavo-client-updater-applet:175
+#: puavo-client-updater-applet:181
 msgid "A new system update is available."
 msgstr "Järjestelmän voi päivittää uuteen."
 
-#: puavo-client-updater-applet:183
+#: puavo-client-updater-applet:189
 msgid "Update cancelled."
 msgstr "Päivitys peruutettu."
 
-#: puavo-client-updater-applet:185
+#: puavo-client-updater-applet:191
 msgid "System update has been cancelled."
 msgstr "Järjestelmän päivitys on peruutettu."
 
-#: puavo-client-updater-applet:193
+#: puavo-client-updater-applet:199
 msgid "Update completed."
 msgstr "Päivitys on valmis."
 
-#: puavo-client-updater-applet:196
+#: puavo-client-updater-applet:202
 msgid "System update is finished, reboot the computer."
 msgstr "Järjestelmän päivitys on tehty, uudelleenkäynnistä tietokone."
 
-#: puavo-client-updater-applet:205 puavo-client-updater-applet:231
+#: puavo-client-updater-applet:211 puavo-client-updater-applet:237
 msgid "Update failed."
 msgstr "Päivitys epäonnistui."
 
-#: puavo-client-updater-applet:207
+#: puavo-client-updater-applet:213
 msgid "An error occurred when updating the system."
 msgstr "Virhe tapahtui päivitettäessä järjestelmää."
 
-#: puavo-client-updater-applet:234
+#: puavo-client-updater-applet:240
 msgid "Update done, reboot required to finish the update."
 msgstr "Päivitys tehty, käyttöönotto vaatii uudelleenkäynnistyksen."
 
-#: puavo-client-updater-applet:237
+#: puavo-client-updater-applet:243
 msgid "Update interrupted."
 msgstr "Päivitys keskeytetty."
 
-#: puavo-client-updater-applet:240
+#: puavo-client-updater-applet:246
 msgid "Up to date."
 msgstr "Päivitetty."
 
-#: puavo-client-updater-applet:267
+#: puavo-client-updater-applet:273
 msgid "Update progress:"
 msgstr "Päivityksen edistyminen:"
 
-#: puavo-client-updater-applet:287
+#: puavo-client-updater-applet:293
 msgid "System update has been started."
 msgstr "Järjestelmän päivitys on käynnistetty."
 
-#: puavo-client-updater-applet:300
+#: puavo-client-updater-applet:306
 msgid "Check for updates"
 msgstr "Tarkista päivitettävyys"
 
-#: puavo-client-updater-applet:303
+#: puavo-client-updater-applet:309
 msgid "(Checking for updates.)"
 msgstr "(Tarkistetaan päivitettävyyttä.)"
 
-#: puavo-client-updater-applet:307
+#: puavo-client-updater-applet:313
 msgid "Update"
 msgstr "Päivitä"
 
-#: puavo-client-updater-applet:310
+#: puavo-client-updater-applet:316
 msgid "Cancel update"
 msgstr "Peruuta päivitys"
 
-#: puavo-client-updater-applet:329
+#: puavo-client-updater-applet:335
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -95,10 +95,10 @@ msgstr ""
 "Vanha versio järjestelmästä sisältää käyttäjän tekemiä muutoksia, jotka "
 "tuhoutuvat päivityksessä. Haluatko jatkaa?"
 
-#: puavo-client-updater-applet:341
+#: puavo-client-updater-applet:347
 msgid "Continue updating?"
 msgstr "Jatka päivittämistä?"
 
-#: puavo-client-updater-applet:346
+#: puavo-client-updater-applet:352
 msgid "Update log"
 msgstr "Päivitysloki"

--- a/puavo-install/po/fi/puavo-client-updater-applet.po
+++ b/puavo-install/po/fi/puavo-client-updater-applet.po
@@ -43,7 +43,7 @@ msgstr "Päivitys on valmis."
 msgid "System update is finished, reboot the computer."
 msgstr "Järjestelmän päivitys on tehty, uudelleenkäynnistä tietokone."
 
-#: puavo-client-updater-applet:220 puavo-client-updater-applet:250
+#: puavo-client-updater-applet:220 puavo-client-updater-applet:251
 msgid "Update failed."
 msgstr "Päivitys epäonnistui."
 
@@ -51,43 +51,43 @@ msgstr "Päivitys epäonnistui."
 msgid "An error occurred when updating the system."
 msgstr "Virhe tapahtui päivitettäessä järjestelmää."
 
-#: puavo-client-updater-applet:253
+#: puavo-client-updater-applet:254
 msgid "Update done, reboot required to finish the update."
 msgstr "Päivitys tehty, käyttöönotto vaatii uudelleenkäynnistyksen."
 
-#: puavo-client-updater-applet:256
+#: puavo-client-updater-applet:257
 msgid "Update interrupted."
 msgstr "Päivitys keskeytetty."
 
-#: puavo-client-updater-applet:259
+#: puavo-client-updater-applet:260
 msgid "Up to date."
 msgstr "Päivitetty."
 
-#: puavo-client-updater-applet:292
+#: puavo-client-updater-applet:295
 msgid "Update progress:"
 msgstr "Päivityksen edistyminen:"
 
-#: puavo-client-updater-applet:307 puavo-client-updater-applet:310
+#: puavo-client-updater-applet:310 puavo-client-updater-applet:313
 msgid "System update has been started."
 msgstr "Järjestelmän päivitys on käynnistetty."
 
-#: puavo-client-updater-applet:335
+#: puavo-client-updater-applet:338
 msgid "Check for updates"
 msgstr "Tarkista päivitettävyys"
 
-#: puavo-client-updater-applet:338
+#: puavo-client-updater-applet:341
 msgid "(Checking for updates.)"
 msgstr "(Tarkistetaan päivitettävyyttä.)"
 
-#: puavo-client-updater-applet:342
+#: puavo-client-updater-applet:345
 msgid "Update"
 msgstr "Päivitä"
 
-#: puavo-client-updater-applet:345
+#: puavo-client-updater-applet:348
 msgid "Cancel update"
 msgstr "Peruuta päivitys"
 
-#: puavo-client-updater-applet:364
+#: puavo-client-updater-applet:367
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -95,10 +95,10 @@ msgstr ""
 "Vanha versio järjestelmästä sisältää käyttäjän tekemiä muutoksia, jotka "
 "tuhoutuvat päivityksessä. Haluatko jatkaa?"
 
-#: puavo-client-updater-applet:376
+#: puavo-client-updater-applet:379
 msgid "Continue updating?"
 msgstr "Jatka päivittämistä?"
 
-#: puavo-client-updater-applet:381
+#: puavo-client-updater-applet:384
 msgid "Update log"
 msgstr "Päivitysloki"

--- a/puavo-install/po/fi/puavo-client-updater-applet.po
+++ b/puavo-install/po/fi/puavo-client-updater-applet.po
@@ -9,85 +9,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: puavo-client-updater-applet:65
+#: puavo-client-updater-applet:67
 msgid "Updates are disabled in developer mode, boot to normal mode to update."
 msgstr ""
 "Päivittäminen ei ole mahdollista kehittäjätilassa, käynnistä normaalitilaan "
 "päivittääksesi."
 
-#: puavo-client-updater-applet:75
+#: puavo-client-updater-applet:77
 msgid "(No update progress.)"
 msgstr "(Ei päivityksen edistymistä.)"
 
-#: puavo-client-updater-applet:92
+#: puavo-client-updater-applet:95
 msgid "View log..."
 msgstr "Näytä loki..."
 
-#: puavo-client-updater-applet:181 puavo-client-updater-applet:183
+#: puavo-client-updater-applet:185 puavo-client-updater-applet:187
 msgid "A new system update is available."
 msgstr "Järjestelmän voi päivittää uuteen."
 
-#: puavo-client-updater-applet:191
+#: puavo-client-updater-applet:196
 msgid "Update cancelled."
 msgstr "Päivitys peruutettu."
 
-#: puavo-client-updater-applet:193
+#: puavo-client-updater-applet:198
 msgid "System update has been cancelled."
 msgstr "Järjestelmän päivitys on peruutettu."
 
-#: puavo-client-updater-applet:201
+#: puavo-client-updater-applet:207
 msgid "Update completed."
 msgstr "Päivitys on valmis."
 
-#: puavo-client-updater-applet:204
+#: puavo-client-updater-applet:210
 msgid "System update is finished, reboot the computer."
 msgstr "Järjestelmän päivitys on tehty, uudelleenkäynnistä tietokone."
 
-#: puavo-client-updater-applet:213 puavo-client-updater-applet:242
+#: puavo-client-updater-applet:220 puavo-client-updater-applet:250
 msgid "Update failed."
 msgstr "Päivitys epäonnistui."
 
-#: puavo-client-updater-applet:215
+#: puavo-client-updater-applet:222
 msgid "An error occurred when updating the system."
 msgstr "Virhe tapahtui päivitettäessä järjestelmää."
 
-#: puavo-client-updater-applet:245
+#: puavo-client-updater-applet:253
 msgid "Update done, reboot required to finish the update."
 msgstr "Päivitys tehty, käyttöönotto vaatii uudelleenkäynnistyksen."
 
-#: puavo-client-updater-applet:248
+#: puavo-client-updater-applet:256
 msgid "Update interrupted."
 msgstr "Päivitys keskeytetty."
 
-#: puavo-client-updater-applet:251
+#: puavo-client-updater-applet:259
 msgid "Up to date."
 msgstr "Päivitetty."
 
-#: puavo-client-updater-applet:278
+#: puavo-client-updater-applet:292
 msgid "Update progress:"
 msgstr "Päivityksen edistyminen:"
 
-#: puavo-client-updater-applet:298 puavo-client-updater-applet:301
+#: puavo-client-updater-applet:307 puavo-client-updater-applet:310
 msgid "System update has been started."
 msgstr "Järjestelmän päivitys on käynnistetty."
 
-#: puavo-client-updater-applet:314
+#: puavo-client-updater-applet:335
 msgid "Check for updates"
 msgstr "Tarkista päivitettävyys"
 
-#: puavo-client-updater-applet:317
+#: puavo-client-updater-applet:338
 msgid "(Checking for updates.)"
 msgstr "(Tarkistetaan päivitettävyyttä.)"
 
-#: puavo-client-updater-applet:321
+#: puavo-client-updater-applet:342
 msgid "Update"
 msgstr "Päivitä"
 
-#: puavo-client-updater-applet:324
+#: puavo-client-updater-applet:345
 msgid "Cancel update"
 msgstr "Peruuta päivitys"
 
-#: puavo-client-updater-applet:343
+#: puavo-client-updater-applet:364
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -95,10 +95,10 @@ msgstr ""
 "Vanha versio järjestelmästä sisältää käyttäjän tekemiä muutoksia, jotka "
 "tuhoutuvat päivityksessä. Haluatko jatkaa?"
 
-#: puavo-client-updater-applet:355
+#: puavo-client-updater-applet:376
 msgid "Continue updating?"
 msgstr "Jatka päivittämistä?"
 
-#: puavo-client-updater-applet:360
+#: puavo-client-updater-applet:381
 msgid "Update log"
 msgstr "Päivitysloki"

--- a/puavo-install/po/sv/puavo-client-updater-applet.po
+++ b/puavo-install/po/sv/puavo-client-updater-applet.po
@@ -61,31 +61,31 @@ msgstr ""
 msgid "Up to date."
 msgstr ""
 
-#: puavo-client-updater-applet:259
+#: puavo-client-updater-applet:264
 msgid "Update progress:"
 msgstr "Uppdateringens framsteg:"
 
-#: puavo-client-updater-applet:279
+#: puavo-client-updater-applet:284
 msgid "System update has been started."
 msgstr ""
 
-#: puavo-client-updater-applet:292
+#: puavo-client-updater-applet:297
 msgid "Check for updates"
 msgstr ""
 
-#: puavo-client-updater-applet:295
+#: puavo-client-updater-applet:300
 msgid "(Checking for updates.)"
 msgstr ""
 
-#: puavo-client-updater-applet:299
+#: puavo-client-updater-applet:304
 msgid "Update"
 msgstr "Uppdatera"
 
-#: puavo-client-updater-applet:302
+#: puavo-client-updater-applet:307
 msgid "Cancel update"
 msgstr ""
 
-#: puavo-client-updater-applet:321
+#: puavo-client-updater-applet:326
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -93,11 +93,11 @@ msgstr ""
 "Den gamla versionen av systemet innehåller konfigurationer som användaren "
 "har gjort, dessa förstörs i uppdateringen. Vill du fortsätta?"
 
-#: puavo-client-updater-applet:333
+#: puavo-client-updater-applet:338
 msgid "Continue updating?"
 msgstr "Fortsät uppdateringen"
 
-#: puavo-client-updater-applet:338
+#: puavo-client-updater-applet:343
 msgid "Update log"
 msgstr "Uppdateringslogg"
 

--- a/puavo-install/po/sv/puavo-client-updater-applet.po
+++ b/puavo-install/po/sv/puavo-client-updater-applet.po
@@ -21,71 +21,71 @@ msgstr ""
 msgid "View log..."
 msgstr "Visa logg..."
 
-#: puavo-client-updater-applet:181
+#: puavo-client-updater-applet:181 puavo-client-updater-applet:183
 msgid "A new system update is available."
 msgstr ""
 
-#: puavo-client-updater-applet:189
+#: puavo-client-updater-applet:191
 msgid "Update cancelled."
 msgstr ""
 
-#: puavo-client-updater-applet:191
+#: puavo-client-updater-applet:193
 msgid "System update has been cancelled."
 msgstr ""
 
-#: puavo-client-updater-applet:199
+#: puavo-client-updater-applet:201
 msgid "Update completed."
 msgstr ""
 
-#: puavo-client-updater-applet:202
+#: puavo-client-updater-applet:204
 msgid "System update is finished, reboot the computer."
 msgstr ""
 
-#: puavo-client-updater-applet:211 puavo-client-updater-applet:237
+#: puavo-client-updater-applet:213 puavo-client-updater-applet:242
 msgid "Update failed."
 msgstr ""
 
-#: puavo-client-updater-applet:213
+#: puavo-client-updater-applet:215
 msgid "An error occurred when updating the system."
 msgstr ""
 
-#: puavo-client-updater-applet:240
+#: puavo-client-updater-applet:245
 msgid "Update done, reboot required to finish the update."
 msgstr ""
 
-#: puavo-client-updater-applet:243
+#: puavo-client-updater-applet:248
 msgid "Update interrupted."
 msgstr ""
 
-#: puavo-client-updater-applet:246
+#: puavo-client-updater-applet:251
 msgid "Up to date."
 msgstr ""
 
-#: puavo-client-updater-applet:273
+#: puavo-client-updater-applet:278
 msgid "Update progress:"
 msgstr "Uppdateringens framsteg:"
 
-#: puavo-client-updater-applet:293
+#: puavo-client-updater-applet:298 puavo-client-updater-applet:301
 msgid "System update has been started."
 msgstr ""
 
-#: puavo-client-updater-applet:306
+#: puavo-client-updater-applet:314
 msgid "Check for updates"
 msgstr ""
 
-#: puavo-client-updater-applet:309
+#: puavo-client-updater-applet:317
 msgid "(Checking for updates.)"
 msgstr ""
 
-#: puavo-client-updater-applet:313
+#: puavo-client-updater-applet:321
 msgid "Update"
 msgstr "Uppdatera"
 
-#: puavo-client-updater-applet:316
+#: puavo-client-updater-applet:324
 msgid "Cancel update"
 msgstr ""
 
-#: puavo-client-updater-applet:335
+#: puavo-client-updater-applet:343
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -93,11 +93,11 @@ msgstr ""
 "Den gamla versionen av systemet innehåller konfigurationer som användaren "
 "har gjort, dessa förstörs i uppdateringen. Vill du fortsätta?"
 
-#: puavo-client-updater-applet:347
+#: puavo-client-updater-applet:355
 msgid "Continue updating?"
 msgstr "Fortsät uppdateringen"
 
-#: puavo-client-updater-applet:352
+#: puavo-client-updater-applet:360
 msgid "Update log"
 msgstr "Uppdateringslogg"
 

--- a/puavo-install/po/sv/puavo-client-updater-applet.po
+++ b/puavo-install/po/sv/puavo-client-updater-applet.po
@@ -9,83 +9,83 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: puavo-client-updater-applet:65
+#: puavo-client-updater-applet:67
 msgid "Updates are disabled in developer mode, boot to normal mode to update."
 msgstr ""
 
-#: puavo-client-updater-applet:75
+#: puavo-client-updater-applet:77
 msgid "(No update progress.)"
 msgstr ""
 
-#: puavo-client-updater-applet:92
+#: puavo-client-updater-applet:95
 msgid "View log..."
 msgstr "Visa logg..."
 
-#: puavo-client-updater-applet:181 puavo-client-updater-applet:183
+#: puavo-client-updater-applet:185 puavo-client-updater-applet:187
 msgid "A new system update is available."
 msgstr ""
 
-#: puavo-client-updater-applet:191
+#: puavo-client-updater-applet:196
 msgid "Update cancelled."
 msgstr ""
 
-#: puavo-client-updater-applet:193
+#: puavo-client-updater-applet:198
 msgid "System update has been cancelled."
 msgstr ""
 
-#: puavo-client-updater-applet:201
+#: puavo-client-updater-applet:207
 msgid "Update completed."
 msgstr ""
 
-#: puavo-client-updater-applet:204
+#: puavo-client-updater-applet:210
 msgid "System update is finished, reboot the computer."
 msgstr ""
 
-#: puavo-client-updater-applet:213 puavo-client-updater-applet:242
+#: puavo-client-updater-applet:220 puavo-client-updater-applet:250
 msgid "Update failed."
 msgstr ""
 
-#: puavo-client-updater-applet:215
+#: puavo-client-updater-applet:222
 msgid "An error occurred when updating the system."
 msgstr ""
 
-#: puavo-client-updater-applet:245
+#: puavo-client-updater-applet:253
 msgid "Update done, reboot required to finish the update."
 msgstr ""
 
-#: puavo-client-updater-applet:248
+#: puavo-client-updater-applet:256
 msgid "Update interrupted."
 msgstr ""
 
-#: puavo-client-updater-applet:251
+#: puavo-client-updater-applet:259
 msgid "Up to date."
 msgstr ""
 
-#: puavo-client-updater-applet:278
+#: puavo-client-updater-applet:292
 msgid "Update progress:"
 msgstr "Uppdateringens framsteg:"
 
-#: puavo-client-updater-applet:298 puavo-client-updater-applet:301
+#: puavo-client-updater-applet:307 puavo-client-updater-applet:310
 msgid "System update has been started."
 msgstr ""
 
-#: puavo-client-updater-applet:314
+#: puavo-client-updater-applet:335
 msgid "Check for updates"
 msgstr ""
 
-#: puavo-client-updater-applet:317
+#: puavo-client-updater-applet:338
 msgid "(Checking for updates.)"
 msgstr ""
 
-#: puavo-client-updater-applet:321
+#: puavo-client-updater-applet:342
 msgid "Update"
 msgstr "Uppdatera"
 
-#: puavo-client-updater-applet:324
+#: puavo-client-updater-applet:345
 msgid "Cancel update"
 msgstr ""
 
-#: puavo-client-updater-applet:343
+#: puavo-client-updater-applet:364
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -93,11 +93,11 @@ msgstr ""
 "Den gamla versionen av systemet innehåller konfigurationer som användaren "
 "har gjort, dessa förstörs i uppdateringen. Vill du fortsätta?"
 
-#: puavo-client-updater-applet:355
+#: puavo-client-updater-applet:376
 msgid "Continue updating?"
 msgstr "Fortsät uppdateringen"
 
-#: puavo-client-updater-applet:360
+#: puavo-client-updater-applet:381
 msgid "Update log"
 msgstr "Uppdateringslogg"
 

--- a/puavo-install/po/sv/puavo-client-updater-applet.po
+++ b/puavo-install/po/sv/puavo-client-updater-applet.po
@@ -41,7 +41,7 @@ msgstr ""
 msgid "System update is finished, reboot the computer."
 msgstr ""
 
-#: puavo-client-updater-applet:220 puavo-client-updater-applet:250
+#: puavo-client-updater-applet:220 puavo-client-updater-applet:251
 msgid "Update failed."
 msgstr ""
 
@@ -49,43 +49,43 @@ msgstr ""
 msgid "An error occurred when updating the system."
 msgstr ""
 
-#: puavo-client-updater-applet:253
+#: puavo-client-updater-applet:254
 msgid "Update done, reboot required to finish the update."
 msgstr ""
 
-#: puavo-client-updater-applet:256
+#: puavo-client-updater-applet:257
 msgid "Update interrupted."
 msgstr ""
 
-#: puavo-client-updater-applet:259
+#: puavo-client-updater-applet:260
 msgid "Up to date."
 msgstr ""
 
-#: puavo-client-updater-applet:292
+#: puavo-client-updater-applet:295
 msgid "Update progress:"
 msgstr "Uppdateringens framsteg:"
 
-#: puavo-client-updater-applet:307 puavo-client-updater-applet:310
+#: puavo-client-updater-applet:310 puavo-client-updater-applet:313
 msgid "System update has been started."
 msgstr ""
 
-#: puavo-client-updater-applet:335
+#: puavo-client-updater-applet:338
 msgid "Check for updates"
 msgstr ""
 
-#: puavo-client-updater-applet:338
+#: puavo-client-updater-applet:341
 msgid "(Checking for updates.)"
 msgstr ""
 
-#: puavo-client-updater-applet:342
+#: puavo-client-updater-applet:345
 msgid "Update"
 msgstr "Uppdatera"
 
-#: puavo-client-updater-applet:345
+#: puavo-client-updater-applet:348
 msgid "Cancel update"
 msgstr ""
 
-#: puavo-client-updater-applet:364
+#: puavo-client-updater-applet:367
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -93,11 +93,11 @@ msgstr ""
 "Den gamla versionen av systemet innehåller konfigurationer som användaren "
 "har gjort, dessa förstörs i uppdateringen. Vill du fortsätta?"
 
-#: puavo-client-updater-applet:376
+#: puavo-client-updater-applet:379
 msgid "Continue updating?"
 msgstr "Fortsät uppdateringen"
 
-#: puavo-client-updater-applet:381
+#: puavo-client-updater-applet:384
 msgid "Update log"
 msgstr "Uppdateringslogg"
 

--- a/puavo-install/po/sv/puavo-client-updater-applet.po
+++ b/puavo-install/po/sv/puavo-client-updater-applet.po
@@ -21,71 +21,71 @@ msgstr ""
 msgid "View log..."
 msgstr "Visa logg..."
 
-#: puavo-client-updater-applet:175
+#: puavo-client-updater-applet:181
 msgid "A new system update is available."
 msgstr ""
 
-#: puavo-client-updater-applet:183
+#: puavo-client-updater-applet:189
 msgid "Update cancelled."
 msgstr ""
 
-#: puavo-client-updater-applet:185
+#: puavo-client-updater-applet:191
 msgid "System update has been cancelled."
 msgstr ""
 
-#: puavo-client-updater-applet:193
+#: puavo-client-updater-applet:199
 msgid "Update completed."
 msgstr ""
 
-#: puavo-client-updater-applet:196
+#: puavo-client-updater-applet:202
 msgid "System update is finished, reboot the computer."
 msgstr ""
 
-#: puavo-client-updater-applet:205 puavo-client-updater-applet:231
+#: puavo-client-updater-applet:211 puavo-client-updater-applet:237
 msgid "Update failed."
 msgstr ""
 
-#: puavo-client-updater-applet:207
+#: puavo-client-updater-applet:213
 msgid "An error occurred when updating the system."
 msgstr ""
 
-#: puavo-client-updater-applet:234
+#: puavo-client-updater-applet:240
 msgid "Update done, reboot required to finish the update."
 msgstr ""
 
-#: puavo-client-updater-applet:237
+#: puavo-client-updater-applet:243
 msgid "Update interrupted."
 msgstr ""
 
-#: puavo-client-updater-applet:240
+#: puavo-client-updater-applet:246
 msgid "Up to date."
 msgstr ""
 
-#: puavo-client-updater-applet:267
+#: puavo-client-updater-applet:273
 msgid "Update progress:"
 msgstr "Uppdateringens framsteg:"
 
-#: puavo-client-updater-applet:287
+#: puavo-client-updater-applet:293
 msgid "System update has been started."
 msgstr ""
 
-#: puavo-client-updater-applet:300
+#: puavo-client-updater-applet:306
 msgid "Check for updates"
 msgstr ""
 
-#: puavo-client-updater-applet:303
+#: puavo-client-updater-applet:309
 msgid "(Checking for updates.)"
 msgstr ""
 
-#: puavo-client-updater-applet:307
+#: puavo-client-updater-applet:313
 msgid "Update"
 msgstr "Uppdatera"
 
-#: puavo-client-updater-applet:310
+#: puavo-client-updater-applet:316
 msgid "Cancel update"
 msgstr ""
 
-#: puavo-client-updater-applet:329
+#: puavo-client-updater-applet:335
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -93,11 +93,11 @@ msgstr ""
 "Den gamla versionen av systemet innehåller konfigurationer som användaren "
 "har gjort, dessa förstörs i uppdateringen. Vill du fortsätta?"
 
-#: puavo-client-updater-applet:341
+#: puavo-client-updater-applet:347
 msgid "Continue updating?"
 msgstr "Fortsät uppdateringen"
 
-#: puavo-client-updater-applet:346
+#: puavo-client-updater-applet:352
 msgid "Update log"
 msgstr "Uppdateringslogg"
 

--- a/puavo-install/po/sv/puavo-client-updater-applet.po
+++ b/puavo-install/po/sv/puavo-client-updater-applet.po
@@ -21,19 +21,19 @@ msgstr ""
 msgid "View log..."
 msgstr "Visa logg..."
 
-#: puavo-client-updater-applet:171
+#: puavo-client-updater-applet:175
 msgid "A new system update is available."
 msgstr ""
 
-#: puavo-client-updater-applet:179
+#: puavo-client-updater-applet:183
 msgid "Update cancelled."
 msgstr ""
 
-#: puavo-client-updater-applet:183
+#: puavo-client-updater-applet:185
 msgid "System update has been cancelled."
 msgstr ""
 
-#: puavo-client-updater-applet:191
+#: puavo-client-updater-applet:193
 msgid "Update completed."
 msgstr ""
 
@@ -41,51 +41,51 @@ msgstr ""
 msgid "System update is finished, reboot the computer."
 msgstr ""
 
-#: puavo-client-updater-applet:205 puavo-client-updater-applet:228
+#: puavo-client-updater-applet:205 puavo-client-updater-applet:231
 msgid "Update failed."
 msgstr ""
 
-#: puavo-client-updater-applet:209
+#: puavo-client-updater-applet:207
 msgid "An error occurred when updating the system."
 msgstr ""
 
-#: puavo-client-updater-applet:231
+#: puavo-client-updater-applet:234
 msgid "Update done, reboot required to finish the update."
 msgstr ""
 
-#: puavo-client-updater-applet:234
+#: puavo-client-updater-applet:237
 msgid "Update interrupted."
 msgstr ""
 
-#: puavo-client-updater-applet:237
+#: puavo-client-updater-applet:240
 msgid "Up to date."
 msgstr ""
 
-#: puavo-client-updater-applet:264
+#: puavo-client-updater-applet:267
 msgid "Update progress:"
 msgstr "Uppdateringens framsteg:"
 
-#: puavo-client-updater-applet:284
+#: puavo-client-updater-applet:287
 msgid "System update has been started."
 msgstr ""
 
-#: puavo-client-updater-applet:297
+#: puavo-client-updater-applet:300
 msgid "Check for updates"
 msgstr ""
 
-#: puavo-client-updater-applet:300
+#: puavo-client-updater-applet:303
 msgid "(Checking for updates.)"
 msgstr ""
 
-#: puavo-client-updater-applet:304
+#: puavo-client-updater-applet:307
 msgid "Update"
 msgstr "Uppdatera"
 
-#: puavo-client-updater-applet:307
+#: puavo-client-updater-applet:310
 msgid "Cancel update"
 msgstr ""
 
-#: puavo-client-updater-applet:326
+#: puavo-client-updater-applet:329
 msgid ""
 "The old version of the system has been edited by the user. Updating the "
 "system causes all these changes to be lost. Do you want to proceed?"
@@ -93,11 +93,11 @@ msgstr ""
 "Den gamla versionen av systemet innehåller konfigurationer som användaren "
 "har gjort, dessa förstörs i uppdateringen. Vill du fortsätta?"
 
-#: puavo-client-updater-applet:338
+#: puavo-client-updater-applet:341
 msgid "Continue updating?"
 msgstr "Fortsät uppdateringen"
 
-#: puavo-client-updater-applet:343
+#: puavo-client-updater-applet:346
 msgid "Update log"
 msgstr "Uppdateringslogg"
 

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -58,19 +58,24 @@ class Updater < DBus::Object
 			 { :pgroup => true })
 
 	stdin.close
-	output, errput = '', ''
-	out_thr = Thread.new { output = stdout.read }
-	err_thr = Thread.new { errput = stderr.read }
+	out_thr = Thread.new do
+	  loop { self.UpdateMessage('ok', stdout.readline) } \
+	    rescue EOFError
+        end
+	err_thr = Thread.new do
+	  loop { self.UpdateMessage('error', stderr.readline) } \
+	    rescue EOFError
+	end
 
 	status = wait_thr.value
 
 	[ out_thr, err_thr ].each { |t| t.join if t }
 
 	if not status.success? then
-	  self.UpdateFailed(output, errput)
-	  raise "failed to update device images: #{ errput }"
+	  self.UpdateFailed
+	  raise "Failed to update device images"
 	end
-	self.UpdateCompleted(output, errput)
+	self.UpdateCompleted
 
       rescue CancelledImageUpdate => e
 	if wait_thr then
@@ -80,11 +85,9 @@ class Updater < DBus::Object
 	  wait_thr.join
 
 	  [ out_thr, err_thr ].each { |t| t.join if t }
-
-	  self.UpdateCancelled(output, errput)
-	else
-	  self.UpdateCancelled('', '')
 	end
+
+	self.UpdateCancelled
 
       ensure
 	[ out_thr, err_thr ].each { |t| t.exit if t }
@@ -95,12 +98,13 @@ class Updater < DBus::Object
 
   dbus_interface "org.puavo.client.update" do
     dbus_signal :UpdateAvailable
-    dbus_signal :UpdateCancelled,         'in outmsg:s, in errmsg:s'
-    dbus_signal :UpdateFailed,            'in outmsg:s, in errmsg:s'
-    dbus_signal :UpdateCompleted,         'in outmsg:s, in errmsg:s'
+    dbus_signal :UpdateCancelled
+    dbus_signal :UpdateCompleted
+    dbus_signal :UpdateFailed
+    dbus_signal :UpdateIsUpToDate,        'in reboot_required:b'
+    dbus_signal :UpdateMessage,           'in msgtype:s, in content:s'
     dbus_signal :UpdateProgressIndicator, 'in phase:s, in progress:i'
     dbus_signal :UpdateStarted
-    dbus_signal :UpdateIsUpToDate,        'in reboot_required:b'
 
     dbus_method :CancelImageUpdate, '' do
       if $image_update_thread then

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -112,7 +112,7 @@ class Updater < DBus::Object
       end
     end
 
-    dbus_method :HasOldOverlays, "out b" do
+    dbus_method :HasOldOverlays, 'out b' do
       output, errput, status \
         = Open3.capture3('/usr/lib/puavo-ltsp-install/ls-old-imageoverlays',
                          '/images',
@@ -124,7 +124,7 @@ class Updater < DBus::Object
     end
 
     dbus_method :Update,
-                'in use_rate_limit:b, in delete_overlays:b, out s' do
+                'in use_rate_limit:b, in delete_overlays:b, out b' do
       |use_rate_limit, delete_overlays|
         Thread.new do
           ($configuration_update_thread || self.configuration_update()) \
@@ -133,23 +133,17 @@ class Updater < DBus::Object
                                                      delete_overlays)) \
             .join
         end
-
-        return "Configuration and image updates triggered.\n"
     end
 
-    dbus_method :UpdateConfiguration, "out s" do
-      return "Configuration update is in progress.\n" \
-        if $configuration_update_thread
-      self.configuration_update()
-      return "Configuration update started.\n"
+    dbus_method :UpdateConfiguration, 'out b' do
+      self.configuration_update() unless $configuration_update_thread
     end
 
     dbus_method :UpdateImages,
-                'in use_rate_limit:b, in delete_overlays:b, out s' do
+                'in use_rate_limit:b, in delete_overlays:b, out b' do
       |use_rate_limit, delete_overlays|
-        return "Image update is in progress.\n" if $image_update_thread
-        self.image_update(use_rate_limit, delete_overlays)
-        return "Image update started.\n"
+        self.image_update(use_rate_limit, delete_overlays) \
+          unless $image_update_thread
     end
 
     dbus_method :UpdateProgress,

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -10,9 +10,8 @@ require 'open3'
 require 'puavo/rest-client'
 require 'socket'
 
-$configuration_update_thread   = nil
-$image_update_thread           = nil
-$notify_puavo_on_images_thread = nil
+$configuration_update_thread = nil
+$image_update_thread         = nil
 
 class CancelledImageUpdate < RuntimeError; end
 
@@ -20,6 +19,12 @@ class Updater < DBus::Object
   def configuration_update
     $configuration_update_thread = Thread.new do
       begin
+	# Notify Puavo on our current image situation.  It is good to do this
+	# on every image update, but also periodically, in case we have booted
+	# to a new image (there might be a better place for this, but at least
+	# the configuration update should be run periodically anyway).
+	notify_puavo_on_images()
+
 	command = '/usr/lib/puavo-ltsp-install/update-configuration'
 
 	output, status = Open3.capture2e(command)
@@ -38,12 +43,6 @@ class Updater < DBus::Object
 	      self.UpdateIsUpToDate(true)  # reboot *is* required
 	  end
 	end
-
-	# Notify Puavo on our current image situation.  It is good to do this
-	# on every image update, but also periodically, in case we have booted
-	# to a new image (there might be a better place for this, but at least
-	# the configuration update should be run periodically anyway).
-	notify_puavo_on_images()
       ensure
 	$configuration_update_thread = nil
       end
@@ -87,7 +86,10 @@ class Updater < DBus::Object
 	end
 	self.UpdateCompleted
 
-	notify_puavo_on_images()
+	# update device information in Puavo and in local disk as well
+	confthread = $configuration_update_thread
+	confthread.join if confthread
+	configuration_update().join
 
       rescue CancelledImageUpdate => e
 	if wait_thr then
@@ -109,50 +111,42 @@ class Updater < DBus::Object
   end
 
   def notify_puavo_on_images
-    Thread.kill($notify_puavo_on_images_thread) \
-      if $notify_puavo_on_images_thread
+    begin
+      available_images \
+	= (Dir.glob('/images/*.img').map { |p| File.basename(p) } \
+	     - %w(ltsp.img ltsp-backup.img)).sort
+      current_image = IO.readlines('/etc/ltsp/this_ltspimage_name') \
+			.first.chomp
 
-    $notify_puavo_on_images_thread = Thread.new do
-      begin
-	available_images \
-	  = (Dir.glob('/images/*.img').map { |p| File.basename(p) } \
-	       - %w(ltsp.img ltsp-backup.img)).sort
-	current_image = IO.readlines('/etc/ltsp/this_ltspimage_name') \
-			  .first.chomp
+      hostname = Socket.gethostname
 
-	hostname = Socket.gethostname
+      # Set :dns => :no because we write stuff to Puavo and we have much
+      # better chances of finding the right server when not using DNS.
+      client = PuavoRestClient.new(:auth => :etc, :dns => :no)
 
-	# Set :dns => :no because we write stuff to Puavo and we have much
-	# better chances of finding the right server when not using DNS.
-	client = PuavoRestClient.new(:auth => :etc, :dns => :no)
+      restpath = "/v3/devices/#{ hostname }"
 
-	restpath = "/v3/devices/#{ hostname }"
+      deviceinfo = JSON.parse( File.read('/state/etc/puavo/device.json') )
 
-	deviceinfo = JSON.parse( File.read('/state/etc/puavo/device.json') )
+      update_available_images \
+	= ((deviceinfo['available_images'] || []).sort != available_images)
+      update_current_image = (deviceinfo['current_image'] != current_image)
 
-	update_available_images \
-	  = ((deviceinfo['available_images'] || []).sort != available_images)
-	update_current_image = (deviceinfo['current_image'] != current_image)
+      puts 'Updating available images in Puavo'  if update_available_images
+      puts 'Updating the current image in Puavo' if update_current_image
 
-	puts 'Updating available images in Puavo'  if update_available_images
-	puts 'Updating the current image in Puavo' if update_current_image
-
-	if update_available_images || update_current_image then
-	  senddata = {
-	    'available_images' => available_images,
-	    'current_image'    => current_image,
-	  }
-	  pres = client.post(restpath, :json => senddata)
-	  raise "Response code for post-request was: #{ pres.code }" \
-	    unless pres.code == 200
-	end
-
-      rescue StandardError => e
-	raise "Could not update image information in Puavo: '#{ e.message }'"
-
-      ensure
-	$notify_puavo_on_images_thread = nil
+      if update_available_images || update_current_image then
+	senddata = {
+	  'available_images' => available_images,
+	  'current_image'    => current_image,
+	}
+	pres = client.post(restpath, :json => senddata)
+	raise "Response code for post-request was: #{ pres.code }" \
+	  unless pres.code == 200
       end
+
+    rescue StandardError => e
+      raise "Could not update image information in Puavo: '#{ e.message }'"
     end
   end
 

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -6,9 +6,12 @@ ENV["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 require 'dbus'
 require 'open3'
+require 'puavo/rest-client'
+require 'socket'
 
-$configuration_update_thread = nil
-$image_update_thread         = nil
+$configuration_update_thread   = nil
+$image_update_thread           = nil
+$notify_puavo_on_images_thread = nil
 
 class CancelledImageUpdate < RuntimeError; end
 
@@ -34,6 +37,12 @@ class Updater < DBus::Object
 	      self.UpdateIsUpToDate(true)  # reboot *is* required
 	  end
 	end
+
+	# Notify Puavo on our current image situation.  It is good to do this
+	# on every image update, but also periodically, in case we have booted
+	# to a new image (there might be a better place for this, but at least
+	# the configuration update should be run periodically anyway).
+	notify_puavo_on_images()
       ensure
 	$configuration_update_thread = nil
       end
@@ -77,6 +86,8 @@ class Updater < DBus::Object
 	end
 	self.UpdateCompleted
 
+	notify_puavo_on_images()
+
       rescue CancelledImageUpdate => e
 	if wait_thr then
 	  if wait_thr.alive? then
@@ -92,6 +103,57 @@ class Updater < DBus::Object
       ensure
 	[ out_thr, err_thr ].each { |t| t.exit if t }
 	$image_update_thread = nil
+      end
+    end
+  end
+
+  def notify_puavo_on_images
+    Thread.kill($notify_puavo_on_images_thread) \
+      if $notify_puavo_on_images_thread
+
+    $notify_puavo_on_images_thread = Thread.new do
+      begin
+	available_images \
+	  = (Dir.glob('/images/*.img').map { |p| File.basename(p) } \
+	       - %w(ltsp.img ltsp-backup.img)).sort
+	current_image = IO.readlines('/etc/ltsp/this_ltspimage_name') \
+			  .first.chomp
+
+	hostname = Socket.gethostname
+
+	# Set :dns => :no because we write stuff to Puavo and we have much
+	# better chances of finding the right server when not using DNS.
+	client = PuavoRestClient.new(:auth => :etc, :dns => :no)
+
+	restpath = "/v3/devices/#{ hostname }"
+
+	gres = client.get(restpath)
+	raise "Response code for get-request was: #{ gres.code }" \
+	  unless gres.code == 200
+	deviceinfo = gres.parse()
+
+	update_available_images \
+	  = ((deviceinfo['available_images'] || []).sort != available_images)
+	update_current_image = (deviceinfo['current_image'] != current_image)
+
+	puts 'Updating available images in Puavo'  if update_available_images
+	puts 'Updating the current image in Puavo' if update_current_image
+
+	if update_available_images || update_current_image then
+	  senddata = {
+	    'available_images' => available_images,
+	    'current_image'    => current_image,
+	  }
+	  pres = client.post(restpath, :json => senddata)
+	  raise "Response code for post-request was: #{ pres.code }" \
+	    unless pres.code == 200
+	end
+
+      rescue StandardError => e
+	raise "Could not update image information in Puavo: '#{ e.message }'"
+
+      ensure
+	$notify_puavo_on_images_thread = nil
       end
     end
   end

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -46,7 +46,7 @@ class Updater < DBus::Object
 
       begin
 	if not system('/usr/lib/puavo-ltsp-install/is-update-available') then
-	  return ''
+	  Thread.exit
 	end
 
 	self.UpdateStarted

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -141,13 +141,6 @@ class Updater < DBus::Object
       self.configuration_update() unless $configuration_update_thread
     end
 
-    dbus_method :UpdateImages,
-                'in use_rate_limit:b, in delete_overlays:b, out b' do
-      |use_rate_limit, delete_overlays|
-        self.image_update(use_rate_limit, delete_overlays) \
-          unless $image_update_thread
-    end
-
     dbus_method :UpdateProgress,
                 "in phase:s, in progress:i" do |phase, progress|
       self.UpdateProgressIndicator(phase, progress)

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -5,6 +5,7 @@
 ENV["PATH"] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 require 'dbus'
+require 'json'
 require 'open3'
 require 'puavo/rest-client'
 require 'socket'
@@ -127,10 +128,7 @@ class Updater < DBus::Object
 
 	restpath = "/v3/devices/#{ hostname }"
 
-	gres = client.get(restpath)
-	raise "Response code for get-request was: #{ gres.code }" \
-	  unless gres.code == 200
-	deviceinfo = gres.parse()
+	deviceinfo = JSON.parse( File.read('/state/etc/puavo/device.json') )
 
 	update_available_images \
 	  = ((deviceinfo['available_images'] || []).sort != available_images)

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -118,24 +118,21 @@ class Updater < DBus::Object
       current_image = IO.readlines('/etc/ltsp/this_ltspimage_name') \
 			.first.chomp
 
-      hostname = Socket.gethostname
-
-      # Set :dns => :no because we write stuff to Puavo and we have much
-      # better chances of finding the right server when not using DNS.
-      client = PuavoRestClient.new(:auth => :etc, :dns => :no)
-
-      restpath = "/v3/devices/#{ hostname }"
-
       deviceinfo = JSON.parse( File.read('/state/etc/puavo/device.json') )
 
       update_available_images \
 	= ((deviceinfo['available_images'] || []).sort != available_images)
       update_current_image = (deviceinfo['current_image'] != current_image)
 
-      puts 'Updating available images in Puavo'  if update_available_images
-      puts 'Updating the current image in Puavo' if update_current_image
-
       if update_available_images || update_current_image then
+        puts 'Updating available images in Puavo'  if update_available_images
+        puts 'Updating the current image in Puavo' if update_current_image
+
+        # Set :dns => :no because we write stuff to Puavo and we have much
+        # better chances of finding the right server when not using DNS.
+        client = PuavoRestClient.new(:auth => :etc, :dns => :no)
+
+        restpath = "/v3/devices/#{ Socket.gethostname }"
 	senddata = {
 	  'available_images' => available_images,
 	  'current_image'    => current_image,

--- a/puavo-install/puavo-client-daemon
+++ b/puavo-install/puavo-client-daemon
@@ -109,6 +109,8 @@ class Updater < DBus::Object
     dbus_method :CancelImageUpdate, '' do
       if $image_update_thread then
         $image_update_thread.raise(CancelledImageUpdate, 'Cancel image update')
+      else
+        self.UpdateCancelled
       end
     end
 

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -163,7 +163,7 @@ class UpdateIndicatorApplet:
                                             self.on_update_completed)
 
 
-    def handle_dbus_error(dbusexception):
+    def handle_dbus_error(self, dbusexception):
         self.append_error_to_log('Unknown dbus error.')
         self.on_update_failed()
 

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -267,8 +267,8 @@ class UpdateIndicatorApplet:
 
         progfn = lambda a, b: int(a + (b - a) * float(progress) / 100)
 
-        # There are two possible image update paths: image_download and
-        # and rdiff_fetch/rdiff_checksum/image_patch are alternative routes
+        # There are two possible image update paths: image_download/image_sync
+        # and rdiff_fetch+rdiff_checksum+image_patch are alternative routes
         # to the same result.
 
         if phase == 'starting':
@@ -283,6 +283,8 @@ class UpdateIndicatorApplet:
             progresstext = '%d%% (patch image)' % progfn(80, 90)
         elif phase == 'image_download':
             progresstext = '%d%% (download image)' % progfn(1, 90)
+        elif phase == 'image_sync':
+            progresstext = '%d%% (sync image)' % progfn(1, 90)
         elif phase == 'image_checksum':
             progresstext = '%d%% (check image)' % progfn(90, 100)
         else:

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -227,10 +227,11 @@ class UpdateIndicatorApplet:
 
 
     def on_update_message(self, msgtype, content):
+        prefixed_message = '    > %s' % content
         if msgtype == 'ok':
-            self.append_text_to_log(content)
+            self.append_text_to_log(prefixed_message)
         elif msgtype == 'error':
-            self.append_error_to_log(content)
+            self.append_error_to_log(prefixed_message)
 
 
     def on_update_progress_indicator(self, phase, progress=0):

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -393,19 +393,17 @@ class UpdateIndicatorApplet:
             self.delete_overlays_dialog.hide()
             if not delete_overlays:
                 # The user has just answered no, so we are not going
-                # to proceed. Returning here is not necessary,
-                # UpdateImages() fails if called with
-                # delete_overlays=False and there exists some
-                # overlays. By returning we avoid generating an
-                # user-visible error which would just confuse the
-                # user.
+                # to proceed.  Returning here is not necessary, because
+                # Update() fails if called with delete_overlays=False
+                # when some overlays exist.  By returning we avoid generating
+                # a user-visible error which would only confuse the user.
                 return
 
         self.update_iface \
-            .UpdateImages(False,
-                          delete_overlays,
-                          reply_handler=lambda reply: None,
-                          error_handler=self.handle_dbus_error)
+            .Update(False,
+                    delete_overlays,
+                    reply_handler=lambda reply: None,
+                    error_handler=self.handle_dbus_error)
 
         self.set_update_button_mode('updating')
         self.on_update_progress_indicator('starting')

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -60,6 +60,8 @@ class UpdateIndicatorApplet:
 
         self.indicator.set_menu(menu)
 
+        self.check_for_updates()
+
 
     def add_disabled_widget(self, menu):
         msg = _tr('Updates are disabled in developer mode, boot to normal mode to update.')
@@ -129,12 +131,12 @@ class UpdateIndicatorApplet:
         self.update_iface.CancelImageUpdate()
 
 
-    def check_for_updates(self, widget):
+    def check_for_updates(self, widget=None):
         self.set_update_button_mode('checking')
 
         self.update_iface \
             .UpdateConfiguration(
-               reply_handler=lambda: None,
+               reply_handler=lambda reply: None,
                error_handler=self.handle_dbus_error)
 
 
@@ -402,7 +404,7 @@ class UpdateIndicatorApplet:
         self.update_iface \
             .UpdateImages(False,
                           delete_overlays,
-                          reply_handler=lambda: None,
+                          reply_handler=lambda reply: None,
                           error_handler=self.handle_dbus_error)
 
         self.set_update_button_mode('updating')

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -241,17 +241,18 @@ class UpdateIndicatorApplet:
             self.set_update_button_mode(mode)
             return
 
-	# It might be strange to have phase 2 two times, but image_download
-	# and rdiff_fetch/rdiff_checksum/image_patch are alternative routes
-	# to the same result.
+        # There are two possible image update paths: image_download and
+        # and rdiff_fetch/rdiff_checksum/image_patch are alternative routes
+        # to the same result.  We use the symbol pi "π" to denote that
+        # we are going through the image download phase.
         phases = {
-          'starting':        '0',
-          'checksums_fetch': '1',
-          'image_download':  '2',
-          'rdiff_fetch':     '2',
-          'rdiff_checksum':  '3',
-          'image_patch':     '4',
-          'image_checksum':  '5',
+          'starting':        u'0',
+          'checksums_fetch': u'1',
+          'rdiff_fetch':     u'2',
+          'rdiff_checksum':  u'3',
+          'image_download':  u'π',
+          'image_patch':     u'4',
+          'image_checksum':  u'5',
         }
 
         try:

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -257,27 +257,32 @@ class UpdateIndicatorApplet:
             self.set_update_button_mode(mode)
             return
 
+        progfn = lambda a, b: int(a + (b - a) * float(progress) / 100)
+
         # There are two possible image update paths: image_download and
         # and rdiff_fetch/rdiff_checksum/image_patch are alternative routes
-        # to the same result.  We use the symbol pi "π" to denote that
-        # we are going through the image download phase.
-        phases = {
-          'starting':        u'0',
-          'checksums_fetch': u'1',
-          'rdiff_fetch':     u'2',
-          'rdiff_checksum':  u'3',
-          'image_download':  u'π',
-          'image_patch':     u'4',
-          'image_checksum':  u'5',
-        }
+        # to the same result.
 
-        try:
-            phase_number = phases[phase]
-        except KeyError:
-            phase_number = '?'
+        if phase == 'starting':
+            progresstext = '0% (starting)'
+        elif phase == 'checksums_fetch':
+            progresstext = '%d%% (fetch checksums)' % progfn(0, 1)
+        elif phase == 'rdiff_fetch':
+            progresstext = '%d%% (fetch rdiff)' % progfn(1, 75)
+        elif phase == 'rdiff_checksum':
+            progresstext = '%d%% (check rdiff)' % progfn(75, 80)
+        elif phase == 'image_patch':
+            progresstext = '%d%% (patch image)' % progfn(80, 90)
+        elif phase == 'image_download':
+            progresstext = '%d%% (download image)' % progfn(1, 90)
+        elif phase == 'image_checksum':
+            progresstext = '%d%% (check image)' % progfn(90, 100)
+        else:
+            # this should not happen, but show that to user anyway (so if a
+            # developer sees this, she can know there is something to fix)
+            progresstext = '???'
 
-        text = '%s (%s/5) %s%%' \
-                 % (_tr('Update progress:'), phase_number, progress)
+        text = '%s %s' % (_tr('Update progress:'), progresstext)
 
         self.set_progress_text(text)
         self.set_update_button_mode('updating')

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -178,6 +178,8 @@ class UpdateIndicatorApplet:
 
         # show only once after each login
         if not self.available_notice_shown:
+            self.append_text_to_log( _tr('A new system update is available.') \
+                                       + "\n" )
             self.notify( _tr('A new system update is available.') )
             self.available_notice_shown = True
 
@@ -223,11 +225,13 @@ class UpdateIndicatorApplet:
             self.indicator.set_icon('update-idle')
             self.indicator.set_status(appindicator.STATUS_ACTIVE)
 
+
     def on_update_message(self, msgtype, content):
         if msgtype == 'ok':
             self.append_text_to_log(content)
         elif msgtype == 'error':
             self.append_error_to_log(content)
+
 
     def on_update_progress_indicator(self, phase, progress=0):
         mode, text = None, None
@@ -289,6 +293,9 @@ class UpdateIndicatorApplet:
         self.set_update_button_mode('updating')
         self.indicator.set_attention_icon('update-downloading')
         self.indicator.set_status(appindicator.STATUS_ATTENTION)
+
+        self.append_text_to_log( _tr('System update has been started.') \
+                                   + "\n" )
 
         self.notify( _tr('System update has been started.') )
 

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -227,7 +227,7 @@ class UpdateIndicatorApplet:
 
 
     def on_update_message(self, msgtype, content):
-        prefixed_message = '    > %s' % content
+        prefixed_message = '        > %s' % content
         if msgtype == 'ok':
             self.append_text_to_log(prefixed_message)
         elif msgtype == 'error':
@@ -366,8 +366,7 @@ class UpdateIndicatorApplet:
         self.log_buffer = gtk.TextBuffer()
 
         self.log_ok_tag    = self.log_buffer.create_tag(foreground='green')
-        self.log_error_tag = self.log_buffer.create_tag(foreground='red',
-                                                        left_margin=20)
+        self.log_error_tag = self.log_buffer.create_tag(foreground='red')
 
         self.log_view = gtk.TextView(self.log_buffer)
         self.log_view.set_editable(False)

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -241,9 +241,13 @@ class UpdateIndicatorApplet:
             self.set_update_button_mode(mode)
             return
 
+	# It might be strange to have phase 2 two times, but image_download
+	# and rdiff_fetch/rdiff_checksum/image_patch are alternative routes
+	# to the same result.
         phases = {
           'starting':        '0',
           'checksums_fetch': '1',
+          'image_download':  '2',
           'rdiff_fetch':     '2',
           'rdiff_checksum':  '3',
           'image_patch':     '4',

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -113,7 +113,9 @@ class UpdateIndicatorApplet:
                              + "\n"
 
         if not error:
-            self.log_buffer.insert_with_tags(end_iter, timestamped_text)
+            self.log_buffer.insert_with_tags(end_iter,
+                                             timestamped_text,
+                                             self.log_ok_tag)
             print(timestamped_text, end='')
         else:
             self.log_buffer.insert_with_tags(end_iter,
@@ -176,7 +178,7 @@ class UpdateIndicatorApplet:
         self.on_update_progress_indicator('interrupted')
         self.on_update_available()
 
-        self.append_text_to_log( _tr('Update cancelled.') + "\n" )
+        self.append_error_to_log( _tr('Update cancelled.') + "\n" )
         self.append_text_to_log(outmsg)
         self.append_error_to_log(errmsg)
 
@@ -202,7 +204,7 @@ class UpdateIndicatorApplet:
         self.indicator.set_attention_icon('update-error')
         self.indicator.set_status(appindicator.STATUS_ATTENTION)
 
-        self.append_text_to_log( _tr('Update failed.') + "\n" )
+        self.append_error_to_log( _tr('Update failed.') + "\n" )
         self.append_text_to_log(outmsg)
         self.append_error_to_log(errmsg)
 
@@ -347,6 +349,8 @@ class UpdateIndicatorApplet:
 
         self.log_dialog.set_default_size(600, 300)
         self.log_buffer = gtk.TextBuffer()
+
+        self.log_ok_tag    = self.log_buffer.create_tag(foreground='green')
         self.log_error_tag = self.log_buffer.create_tag(foreground='red',
                                                         left_margin=20)
 

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -133,8 +133,9 @@ class UpdateIndicatorApplet:
         self.set_update_button_mode('checking')
 
         self.update_iface \
-            .UpdateConfiguration(reply_handler=self.append_text_to_log,
-                                 error_handler=self.append_error_to_log)
+            .UpdateConfiguration(
+               reply_handler=lambda: None,
+               error_handler=self.handle_dbus_error)
 
 
     def connect_to_dbus(self):
@@ -158,6 +159,11 @@ class UpdateIndicatorApplet:
                                             self.on_update_failed)
         self.update_iface.connect_to_signal('UpdateCompleted',
                                             self.on_update_completed)
+
+
+    def handle_dbus_error(dbusexception):
+        self.append_error_to_log('Unknown dbus error.')
+        self.on_update_failed()
 
 
     def notify(self, msg):
@@ -389,8 +395,8 @@ class UpdateIndicatorApplet:
         self.update_iface \
             .UpdateImages(False,
                           delete_overlays,
-                          reply_handler=self.append_text_to_log,
-                          error_handler=self.append_error_to_log)
+                          reply_handler=lambda: None,
+                          error_handler=self.handle_dbus_error)
 
         self.set_update_button_mode('updating')
         self.on_update_progress_indicator('starting')

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -174,12 +174,11 @@ class UpdateIndicatorApplet:
 
 
     def on_update_available(self):
+        self.stop_roll_progress()
         self.set_update_button_mode('update')
 
         self.indicator.set_attention_icon('update-available')
         self.indicator.set_status(appindicator.STATUS_ATTENTION)
-
-        self.stop_roll_progress()
 
         # show only once after each login
         if not self.available_notice_shown:
@@ -190,6 +189,7 @@ class UpdateIndicatorApplet:
 
 
     def on_update_cancelled(self):
+        self.stop_roll_progress()
         self.on_update_progress_indicator('interrupted')
         self.on_update_available()
 
@@ -197,10 +197,9 @@ class UpdateIndicatorApplet:
 
         self.notify( _tr('System update has been cancelled.') )
 
-        self.stop_roll_progress()
-
 
     def on_update_completed(self):
+        self.stop_roll_progress()
         self.set_update_button_mode('check')
 
         self.on_update_isuptodate(True)
@@ -210,10 +209,9 @@ class UpdateIndicatorApplet:
         self.available_notice_shown = False
         self.notify( _tr('System update is finished, reboot the computer.') )
 
-        self.stop_roll_progress()
-
 
     def on_update_failed(self):
+        self.stop_roll_progress()
         self.set_update_button_mode('update')
 
         self.indicator.set_attention_icon('update-error')
@@ -223,10 +221,10 @@ class UpdateIndicatorApplet:
 
         self.notify( _tr('An error occurred when updating the system.') )
 
-        self.stop_roll_progress()
-
 
     def on_update_isuptodate(self, reboot_required):
+        self.stop_roll_progress()
+
         if reboot_required:
             self.on_update_progress_indicator('finished')
             self.indicator.set_attention_icon('update-installed')
@@ -235,8 +233,6 @@ class UpdateIndicatorApplet:
             self.on_update_progress_indicator('uptodate')
             self.indicator.set_icon('update-idle')
             self.indicator.set_status(appindicator.STATUS_ACTIVE)
-
-        self.stop_roll_progress()
 
 
     def on_update_message(self, msgtype, content):
@@ -264,9 +260,9 @@ class UpdateIndicatorApplet:
             text = _tr('Up to date.')
 
         if mode and text:
+            self.stop_roll_progress()
             self.set_progress_text(text)
             self.set_update_button_mode(mode)
-            self.stop_roll_progress()
             return
 
         progfn = lambda a, b: int(a + (b - a) * float(progress) / 100)

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -146,6 +146,8 @@ class UpdateIndicatorApplet:
                                             self.on_update_isuptodate)
         self.update_iface.connect_to_signal('UpdateAvailable',
                                             self.on_update_available)
+        self.update_iface.connect_to_signal('UpdateMessage',
+                                            self.on_update_message)
         self.update_iface.connect_to_signal('UpdateStarted',
                                             self.on_update_started)
         self.update_iface.connect_to_signal('UpdateProgressIndicator',
@@ -174,39 +176,33 @@ class UpdateIndicatorApplet:
             self.available_notice_shown = True
 
 
-    def on_update_cancelled(self, outmsg, errmsg):
+    def on_update_cancelled(self):
         self.on_update_progress_indicator('interrupted')
         self.on_update_available()
 
         self.append_error_to_log( _tr('Update cancelled.') + "\n" )
-        self.append_text_to_log(outmsg)
-        self.append_error_to_log(errmsg)
 
         self.notify( _tr('System update has been cancelled.') )
 
 
-    def on_update_completed(self, outmsg, errmsg):
+    def on_update_completed(self):
         self.set_update_button_mode('check')
 
         self.on_update_isuptodate(True)
 
         self.append_text_to_log( _tr('Update completed.') + "\n" )
-        self.append_text_to_log(outmsg)
-        self.append_error_to_log(errmsg)
 
         self.available_notice_shown = False
         self.notify( _tr('System update is finished, reboot the computer.') )
 
 
-    def on_update_failed(self, outmsg, errmsg):
+    def on_update_failed(self):
         self.set_update_button_mode('update')
 
         self.indicator.set_attention_icon('update-error')
         self.indicator.set_status(appindicator.STATUS_ATTENTION)
 
         self.append_error_to_log( _tr('Update failed.') + "\n" )
-        self.append_text_to_log(outmsg)
-        self.append_error_to_log(errmsg)
 
         self.notify( _tr('An error occurred when updating the system.') )
 
@@ -221,6 +217,11 @@ class UpdateIndicatorApplet:
             self.indicator.set_icon('update-idle')
             self.indicator.set_status(appindicator.STATUS_ACTIVE)
 
+    def on_update_message(self, msgtype, content):
+        if msgtype == 'ok':
+            self.append_text_to_log(content)
+        elif msgtype == 'error':
+            self.append_error_to_log(content)
 
     def on_update_progress_indicator(self, phase, progress=0):
         mode, text = None, None

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -41,7 +41,7 @@ class UpdateIndicatorApplet:
 
         if is_on_persistent_overlay():
             self.add_disabled_widget(menu)
-	    self.indicator.set_menu(menu)
+            self.indicator.set_menu(menu)
             return
 
         pynotify.init('puavo-client-updater-applet')
@@ -62,12 +62,12 @@ class UpdateIndicatorApplet:
 
 
     def add_disabled_widget(self, menu):
-	msg = _tr('Updates are disabled in developer mode, boot to normal mode to update.')
-	self.disabled_msg = gtk.MenuItem(msg)
-	self.disabled_msg.set_sensitive(False)
-	self.disabled_msg.show()
+        msg = _tr('Updates are disabled in developer mode, boot to normal mode to update.')
+        self.disabled_msg = gtk.MenuItem(msg)
+        self.disabled_msg.set_sensitive(False)
+        self.disabled_msg.show()
 
-	menu.append(self.disabled_msg)
+        menu.append(self.disabled_msg)
 
 
     def add_progress(self, menu):

--- a/puavo-install/puavo-client-updater-applet
+++ b/puavo-install/puavo-client-updater-applet
@@ -12,6 +12,7 @@ _tr = gettext.gettext
 import appindicator
 import dbus
 import dbus.mainloop.glib
+import gobject
 import grp
 import gtk
 import os
@@ -47,8 +48,7 @@ class UpdateIndicatorApplet:
         pynotify.init('puavo-client-updater-applet')
         self.available_notice_shown = False
         self.download_animation_icons \
-          = [ 'update-downloading' ] \
-              + [ 'update-downloading-%02d' % x for x in range(2, 14) ]
+          = [ 'update-downloading-%02d' % x for x in range(1, 14) ]
 
         self.add_update_button(menu)
         self.add_view_log_button(menu)
@@ -77,6 +77,7 @@ class UpdateIndicatorApplet:
         self.set_progress_text( _tr('(No update progress.)') )
         self.progress.set_sensitive(False)
         self.progress.show()
+        self.roll_progress_id = None
 
         menu.append(self.progress)
 
@@ -178,6 +179,8 @@ class UpdateIndicatorApplet:
         self.indicator.set_attention_icon('update-available')
         self.indicator.set_status(appindicator.STATUS_ATTENTION)
 
+        self.stop_roll_progress()
+
         # show only once after each login
         if not self.available_notice_shown:
             self.append_text_to_log( _tr('A new system update is available.') \
@@ -194,6 +197,8 @@ class UpdateIndicatorApplet:
 
         self.notify( _tr('System update has been cancelled.') )
 
+        self.stop_roll_progress()
+
 
     def on_update_completed(self):
         self.set_update_button_mode('check')
@@ -204,6 +209,8 @@ class UpdateIndicatorApplet:
 
         self.available_notice_shown = False
         self.notify( _tr('System update is finished, reboot the computer.') )
+
+        self.stop_roll_progress()
 
 
     def on_update_failed(self):
@@ -216,6 +223,8 @@ class UpdateIndicatorApplet:
 
         self.notify( _tr('An error occurred when updating the system.') )
 
+        self.stop_roll_progress()
+
 
     def on_update_isuptodate(self, reboot_required):
         if reboot_required:
@@ -226,6 +235,8 @@ class UpdateIndicatorApplet:
             self.on_update_progress_indicator('uptodate')
             self.indicator.set_icon('update-idle')
             self.indicator.set_status(appindicator.STATUS_ACTIVE)
+
+        self.stop_roll_progress()
 
 
     def on_update_message(self, msgtype, content):
@@ -255,6 +266,7 @@ class UpdateIndicatorApplet:
         if mode and text:
             self.set_progress_text(text)
             self.set_update_button_mode(mode)
+            self.stop_roll_progress()
             return
 
         progfn = lambda a, b: int(a + (b - a) * float(progress) / 100)
@@ -287,14 +299,9 @@ class UpdateIndicatorApplet:
         self.set_progress_text(text)
         self.set_update_button_mode('updating')
 
-        self.indicator.set_attention_icon(self.download_animation_icons[0])
-        self.indicator.set_status(appindicator.STATUS_ATTENTION)
-
-        # cycle attention icons
-        self.download_animation_icons \
-          = self.download_animation_icons[1:] \
-              + [ self.download_animation_icons[0] ]
-
+        if not self.roll_progress_id:
+            self.roll_progress_id \
+              = gobject.timeout_add(250, self.roll_progress_animation)
 
 
     def on_update_started(self):
@@ -306,6 +313,18 @@ class UpdateIndicatorApplet:
                                    + "\n" )
 
         self.notify( _tr('System update has been started.') )
+
+
+    def roll_progress_animation(self):
+        self.indicator.set_attention_icon(self.download_animation_icons[0])
+        self.indicator.set_status(appindicator.STATUS_ATTENTION)
+
+        # cycle attention icons
+        self.download_animation_icons         \
+          = self.download_animation_icons[1:] \
+              + [ self.download_animation_icons[0] ]
+
+        return True
 
 
     def set_progress_text(self, text):
@@ -386,6 +405,12 @@ class UpdateIndicatorApplet:
         log_scroll.show()
 
         self.log_dialog.vbox.pack_start(log_scroll)
+
+
+    def stop_roll_progress(self):
+        if self.roll_progress_id:
+            gobject.source_remove(self.roll_progress_id)
+            self.roll_progress_id = None
 
 
     def update_image(self, widget):

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -3,14 +3,17 @@
 # obtain an exclusive lock on myself...
 # there should be only one instance of this program running
 
-exec 3<$0
-flock -nx 3 || { echo did not get a lock, exiting; exit 1; }
+exec 4<$0
+flock -nx 4 || { echo did not get a lock, exiting; exit 1; }
 
 #
 # argument parsing
 #
 
 set -eu
+
+exec 5>&1	# another way to write to stdout for log()
+exec 6>&2	# another way to write to stderr for log()
 
 log() {
   log_to_stdout=false
@@ -29,8 +32,8 @@ log() {
       ;;
   esac
 
-  $log_to_stdout && echo "$logmessage"
-  $log_to_stderr && echo "$logmessage" >&2
+  $log_to_stdout && echo "$logmessage" >&5
+  $log_to_stderr && echo "$logmessage" >&6
 
   echo "$logmessage" \
     | logger -p "$logpriority" -t puavo-install-and-update-ltspimages

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -94,7 +94,7 @@ while [ $# -ne 0 ]; do
       # rsync (--bwlimit) and wget (--limit-rate) understand.
       rate_limit="$2"; shift; shift
       if ! echo "$rate_limit" | grep -Eqx '[0-9]+[km]'; then
-        log err "The rate limit was not understood, got '$rate_limit'"
+        log err "the rate limit was not understood, got '$rate_limit'"
         usage
       fi
       ;;
@@ -173,7 +173,7 @@ check_checksums_exist_for() {
   for file_to_check_checksum_for in "$@"; do
     if ! lookup_size_from_cksums "$checksums_file" \
                                  "$file_to_check_checksum_for" >/dev/null; then
-      log err "Could not find checksum for '$file_to_check_checksum_for'"
+      log err "could not find checksum for '$file_to_check_checksum_for'"
       return 1
     fi
   done
@@ -218,8 +218,7 @@ check_with_cksum() {
     log info "checksum for file $filename is okay"
     return 0
   else
-    log err \
-      "file $filename failed checksum check, removing $actual_file_path"
+    log err "file $filename failed checksum check, removing $actual_file_path"
     rm -f "$actual_file_path"
     return 1
   fi
@@ -297,18 +296,18 @@ ensure_that_default_image_is_the_current_one() {
   default_image=$(lookup_ltspimage_name_by_alias ltsp.img || true)
 
   if [ -z "$booted_image" ]; then
-    log err "Could not determine the current ltspimage"
+    log err "could not determine the current ltspimage"
     return 1
   fi
 
   if [ "$booted_image" != "$default_image" ]; then
     if [ ! -e "${images_dir}/${booted_image}" ]; then
-      log err "Booted from image '${booted_image}', but it does not exist!"
+      log err "booted from image '${booted_image}', but it does not exist!"
       return 1
     fi
 
     log notice \
-        "Not booted the default image, setting '${booted_image}' as default"
+        "not booted the default image, setting '${booted_image}' as default"
     set_image_as_default_image "$booted_image"
   fi
 }
@@ -386,7 +385,7 @@ get_next_image() {
   previous_image=$(lookup_ltspimage_name_by_alias ltsp.img || true)
 
   if [ -z "$previous_image" ]; then
-    log err 'Could not determine the current ltsp image name'
+    log err 'could not determine the current ltsp image name'
     return 1
   fi
 
@@ -504,7 +503,7 @@ install_from_file_or_nbd() {
 		       ')
       ;;
     *)
-      log err "Internal error in install_from_file_or_nbd()"
+      log err "internal error in install_from_file_or_nbd()"
       return 1
       ;;
   esac
@@ -618,7 +617,7 @@ patch_with_rdiff() {
 
   if ! next_image_filesize=$(lookup_size_from_cksums "$checksums_file" \
                                                      "$next_image"); then
-    log err "Could not lookup image size from CKSUMS for '${next_image}'"
+    log err "could not lookup image size from CKSUMS for '${next_image}'"
     return 1
   fi
 

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -328,7 +328,7 @@ fetch_with_wget() {
   )
 
   if [ -n "$wget_error_code" ]; then
-    log err "fetching $url, wget returned error code $wget_error_code"
+    log err "fetching $url, wget error code $wget_error_code"
     return 1
   fi
 
@@ -724,7 +724,7 @@ try_full_image_update_from_imageserver() {
   if [ -z "$rsync_error_code" ]; then
     log info "rsync fetched the image $next_image with success"
   else
-    log err "error in rsyncing ${remote_rsyncpath}: $rsync_error_code"
+    log err "rsyncing ${remote_rsyncpath}: rsync error code $rsync_error_code"
     httpurl="https://${image_server}/${next_image}"
     log info "falling back to fetching $httpurl"
     fetch_with_wget "$rate_limit"         \

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -323,7 +323,7 @@ get_next_image() {
   next_image=$1
   rate_limit_opts=$2
 
-  image_server=$(lookup_image_server_from_dns)
+  image_server_list=$(lookup_image_servers)
 
   rdiffs_dir="${images_dir}/rdiffs"
   previous_image=$(lookup_ltspimage_name_by_alias ltsp.img || true)
@@ -345,23 +345,24 @@ get_next_image() {
 
   ensure_enough_available_diskspace "$rdiffs_dir"
 
-  checksums_file=$(
-    get_checksums_file "$rate_limit_opts" \
-		       "https://${image_server}/rdiffs/CKSUMS")
+  for image_server in $image_server_list; do
+    try_rdiff_update_from_imageserver "$image_server"    \
+				      "$rate_limit_opts" \
+				      "$rdiff_filename"  \
+				      "$rdiffs_dir"      \
+				      "$previous_image"  \
+				      "$next_image"      \
+      && return 0
+  done
 
-  rdiff_url="https://${image_server}/rdiffs/${rdiff_filename}"
+  # We have failed with updates through rdiff, we try rsync fallback to all
+  # servers in $image_server_list.
 
-  get_rdiff "$rdiffs_dir"      \
-	    "$rate_limit_opts" \
-	    "$rdiff_filename"  \
-	    "$rdiff_url"       \
-	    "$checksums_file"
+  for image_server in $image_server_list; do
+    : # XXX
+  done
 
-  patch_with_rdiff "$rdiffs_dir"     \
-		   "$previous_image" \
-		   "$next_image"     \
-		   "$rdiff_filename" \
-		   "$checksums_file"
+  return 1
 }
 
 get_rdiff() {
@@ -489,26 +490,35 @@ lookup_filesize_from_cksums() {
   ' "${images_dir}/CKSUMS"
 }
 
-lookup_image_server_from_dns() {
+lookup_image_servers() {
+  all_image_servers=
+
   puavo_domain=$(cat /etc/puavo/domain)
-  image_server=$(
+  image_server_by_dns=$(
     dig SRV "_imageserver._tcp.${puavo_domain}" +search +short \
       | awk '{ sub(/\.$/, ""); printf "%s:%s", $4, $3 }')
 
-  if [ -z "$image_server" ]; then
-    # XXX take only the first image_server from "imageservers"...
-    # XXX we are not yet capable of trying out several servers
-    image_server=$(jq -r '.imageservers[]' /etc/puavo/device.json \
-		     2>/dev/null | head -1) || true
-    if [ -z "$image_server" ]; then
-      image_server="images.$(cat /etc/puavo/topdomain)"
-      log info "$(printf "%s %s\n" \
-			 "could not find the image server from DNS, " \
-			 "falling back to $image_server")"
-    fi
+  if [ -z "$image_server_by_dns" ]; then
+    log info 'could not find the image server from DNS'
+  else
+    all_image_servers="$all_image_servers $image_server_by_dns"
   fi
 
-  echo "$image_server"
+  # XXX not used yet, it is unclear if this will ever be?
+  image_servers_by_devicejson=$(
+    jq -r '.imageservers[]' /etc/puavo/device.json 2>/dev/null || true)
+
+  if [ -n "$image_servers_by_devicejson" ]; then
+    all_image_servers="$all_image_servers $image_servers_by_devicejson"
+  fi
+
+  toplevel_image_server="images.$(cat /etc/puavo/topdomain)"
+
+  all_image_servers="$all_image_servers $toplevel_image_server"
+
+  log info "using image servers: $(echo "$all_image_servers" | xargs)"
+
+  echo "$all_image_servers"
 }
 
 lookup_ltspimage_name_by_alias() {
@@ -627,6 +637,33 @@ set_image_as_default_image() {
   log notice "new ltsp image $next_image has been set as default"
 
   update_stats finished 100
+}
+
+try_rdiff_update_from_imageserver() {
+  image_server=$1
+  rate_limit_opts=$2
+  rdiff_filename=$3
+  rdiffs_dir=$4
+  previous_image=$5
+  next_image=$6
+
+  checksums_file=$(
+    get_checksums_file "$rate_limit_opts" \
+		       "https://${image_server}/rdiffs/CKSUMS")
+
+  rdiff_url="https://${image_server}/rdiffs/${rdiff_filename}"
+
+  get_rdiff "$rdiffs_dir"      \
+	    "$rate_limit_opts" \
+	    "$rdiff_filename"  \
+	    "$rdiff_url"       \
+	    "$checksums_file"
+
+  patch_with_rdiff "$rdiffs_dir"     \
+		   "$previous_image" \
+		   "$next_image"     \
+		   "$rdiff_filename" \
+		   "$checksums_file"
 }
 
 update_image() {

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -359,11 +359,10 @@ get_next_image() {
     return 1
   fi
 
-  rdiff_filename=$(get_rdiff_filename $previous_image $next_image) || {
-      log err "failed to determine the filename of rdiff between images \
-'${previous_image}' and '${next_image}'"
-      return 1
-  }
+  if ! rdiff_filename=$(get_rdiff_filename $previous_image $next_image); then
+    log err "failed to determine the rdiff filename between '${previous_image}' and '${next_image}'"
+    return 1
+  fi
 
   mkdir -p "$rdiffs_dir"
 

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -326,8 +326,7 @@ fetch_with_wget() {
 	    BEGIN { progress = -1 }
 
 	    {
-	      percentage = substr($0, 63, 4)
-	      if (match(percentage, /^[[:space:]]*([[:digit:]]+)%$/, a)) {
+	      if (match($7, /^([[:digit:]]+)%$/, a)) {
 		new_progress = a[1]
 		if (progress != new_progress) {
 		  progress = new_progress

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -147,6 +147,24 @@ trap interrupted INT TERM
 # subroutines
 #
 
+check_image_and_put_it_to_use() {
+  next_image=$1
+  next_image_tmppath=$2
+  checksums_file=$3
+
+  check_with_cksum "$next_image"         \
+                   "$next_image_tmppath" \
+                   "$checksums_file"     \
+                   image_checksum        \
+    || return 1
+
+  sync                                                   || return 1
+  mv "$next_image_tmppath" "${images_dir}/${next_image}" || return 1
+  sync                                                   || return 1
+
+  log notice "new ltsp image $next_image has been put into its place"
+}
+
 check_with_cksum() {
   filename=$1
   actual_file_path=$2
@@ -313,10 +331,11 @@ get_checksums_file() {
   fetch_with_wget "$extra_wget_opts"          \
 		  "${checksum_file_path}.tmp" \
 		  "$url"                      \
-                  checksums_fetch
-  mv "${checksum_file_path}.tmp" "${checksum_file_path}"
+                  checksums_fetch             \
+    || return 1
+  mv "${checksum_file_path}.tmp" "${checksum_file_path}" || return 1
 
-  echo "${checksum_file_path}"
+  echo "${checksum_file_path}" || return 1
 }
 
 get_next_image() {
@@ -359,7 +378,8 @@ get_next_image() {
   # servers in $image_server_list.
 
   for image_server in $image_server_list; do
-    : # XXX
+    # XXX to be done
+    false && return 0
   done
 
   return 1
@@ -382,14 +402,16 @@ get_rdiff() {
   log info "we are missing the full rdiff $rdiff_filename, going to get it"
 
   rdiff_tmp="${rdiff_path}.tmp"
-  fetch_with_wget  "$extra_wget_opts" "$rdiff_tmp" "$rdiff_url" rdiff_fetch
+  fetch_with_wget "$extra_wget_opts" "$rdiff_tmp" "$rdiff_url" rdiff_fetch \
+    || return 1
   check_with_cksum "$rdiff_filename" \
                    "$rdiff_tmp"      \
                    "$checksums_file" \
-                   rdiff_checksum
+                   rdiff_checksum    \
+    || return 1
 
-  sync
-  mv "$rdiff_tmp" "$rdiff_path"
+  sync || return 1
+  mv "$rdiff_tmp" "$rdiff_path" || return 1
 
   log notice "new rdiff file $rdiff_filename has been put into its place"
 }
@@ -557,27 +579,26 @@ patch_with_rdiff() {
     return 1
   fi
 
+  next_image_tmppath="${images_dir}/${next_image}.tmp"
+
   # rdiff might fail due to a corrupt rdiff-file or for some other reason.
   # We let rdiff pass through in case of failure, and we check the correctness
   # of the output right after (removing the output if the checksum is bad).
+  # (Note that we do not use pipefail, so with pv the rdiff status code does
+  # not matter anyway).
   {
     rdiff patch "${images_dir}/${previous_image}" \
 		"${rdiffs_dir}/${rdiff_filename}" \
 		-                                 \
       | { pv -n -s "$next_image_filesize" 3>&1 1>&2 2>&3 3>&- \
             | update_stats_with_progress image_patch; } \
-      > "${images_dir}/${next_image}.tmp" 2>&1
+      > "$next_image_tmppath" 2>&1
   } || true
 
-  check_with_cksum "$next_image"                     \
-		   "${images_dir}/${next_image}.tmp" \
-		   "$checksums_file"                 \
-		   image_checksum
-
-  sync
-  mv "${images_dir}/${next_image}.tmp" "${images_dir}/${next_image}"
-
-  log notice "new ltsp image $next_image has been put into its place"
+  check_image_and_put_it_to_use "$next_image"         \
+                                "$next_image_tmppath" \
+                                "$checksums_file"     \
+    || return 1
 }
 
 query_update_confirmation() {
@@ -649,7 +670,8 @@ try_rdiff_update_from_imageserver() {
 
   checksums_file=$(
     get_checksums_file "$rate_limit_opts" \
-		       "https://${image_server}/rdiffs/CKSUMS")
+		       "https://${image_server}/rdiffs/CKSUMS") \
+      || return 1
 
   rdiff_url="https://${image_server}/rdiffs/${rdiff_filename}"
 
@@ -657,13 +679,15 @@ try_rdiff_update_from_imageserver() {
 	    "$rate_limit_opts" \
 	    "$rdiff_filename"  \
 	    "$rdiff_url"       \
-	    "$checksums_file"
+	    "$checksums_file"  \
+    || return 1
 
   patch_with_rdiff "$rdiffs_dir"     \
 		   "$previous_image" \
 		   "$next_image"     \
 		   "$rdiff_filename" \
-		   "$checksums_file"
+		   "$checksums_file" \
+    || return 1
 }
 
 update_image() {

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -155,6 +155,19 @@ trap interrupted INT TERM
 # subroutines
 #
 
+check_checksums_exist_for() {
+  checksums_file=$1; shift
+  for file_to_check_checksum_for in "$@"; do
+    if ! lookup_size_from_cksums "$checksums_file" \
+                                 "$file_to_check_checksum_for" >/dev/null; then
+      log err "Could not find checksum for '$file_to_check_checksum_for'"
+      return 1
+    fi
+  done
+
+  return 0
+}
+
 check_image_and_put_it_to_use() {
   next_image=$1
   next_image_tmppath=$2
@@ -377,12 +390,12 @@ get_next_image() {
   ensure_enough_available_diskspace "$rdiffs_dir"
 
   for image_server in $image_server_list; do
-    try_rdiff_update_from_imageserver "$image_server"    \
-				      "$rate_limit"      \
-				      "$rdiff_filename"  \
-				      "$rdiffs_dir"      \
-				      "$previous_image"  \
-				      "$next_image"      \
+    try_rdiff_update_from_imageserver "$image_server"   \
+				      "$rate_limit"     \
+				      "$rdiff_filename" \
+				      "$rdiffs_dir"     \
+				      "$previous_image" \
+				      "$next_image"     \
       && return 0
   done
 
@@ -518,12 +531,15 @@ install_image() {
   echo "is now installed and set as default."
 }
 
-lookup_filesize_from_cksums() {
-  awk -v filename="$(basename "$1")" '
+lookup_size_from_cksums() {
+  checksums_file=$1
+  file_to_look_filesize_for=$2
+
+  awk -v filename="$file_to_look_filesize_for" '
     BEGIN { status = 1 }
     $3 == filename { print $2; status = 0 }
     END { exit(status) }
-  ' "${images_dir}/CKSUMS"
+  ' "$checksums_file"
 }
 
 lookup_image_servers() {
@@ -588,7 +604,8 @@ patch_with_rdiff() {
   rdiff_filename=$4
   checksums_file=$5
 
-  if ! next_image_filesize=$(lookup_filesize_from_cksums "$next_image"); then
+  if ! next_image_filesize=$(lookup_size_from_cksums "$checksums_file" \
+                                                     "$next_image"); then
     log err "Could not lookup image size from CKSUMS for '${next_image}'"
     return 1
   fi
@@ -683,6 +700,9 @@ try_full_image_update_from_imageserver() {
     get_checksums_file "$rate_limit" "https://${image_server}/CKSUMS") \
       || return 1
 
+  # it is not sensible to continue if the required checksum does not exist
+  check_checksums_exist_for "$checksums_file" "$next_image" || return 1
+
   next_image_tmppath="${images_dir}/${next_image}.tmp"
 
   rsyncopts=""
@@ -751,6 +771,10 @@ try_rdiff_update_from_imageserver() {
   checksums_file=$(
     get_checksums_file "$rate_limit" "https://${image_server}/CKSUMS") \
       || return 1
+
+  # it is not sensible to continue if the required checksums do not exist
+  check_checksums_exist_for "$checksums_file" "$rdiff_filename" "$next_image" \
+    || return 1
 
   rdiff_url="https://${image_server}/rdiffs/${rdiff_filename}"
 

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -3,8 +3,8 @@
 # obtain an exclusive lock on myself...
 # there should be only one instance of this program running
 
-exec 4<$0
-flock -nx 4 || { echo did not get a lock, exiting; exit 1; }
+exec 3<$0
+flock -nx 3 || { echo did not get a lock, exiting; exit 1; }
 
 #
 # argument parsing
@@ -12,8 +12,8 @@ flock -nx 4 || { echo did not get a lock, exiting; exit 1; }
 
 set -eu
 
-exec 5>&1	# another way to write to stdout for log()
-exec 6>&2	# another way to write to stderr for log()
+exec 4>&1	# another way to write to stdout for log()
+exec 5>&2	# another way to write to stderr for log()
 
 log() {
   log_to_stdout=false
@@ -32,8 +32,8 @@ log() {
       ;;
   esac
 
-  $log_to_stdout && echo "$logmessage" >&5
-  $log_to_stderr && echo "$logmessage" >&6
+  $log_to_stdout && echo "$logmessage" >&4
+  $log_to_stderr && echo "$logmessage" >&5
 
   echo "$logmessage" \
     | logger -p "$logpriority" -t puavo-install-and-update-ltspimages
@@ -329,33 +329,32 @@ fetch_with_wget() {
     wgetopts="--limit-rate=$rate_limit"
   fi
 
-  wget_error_code=$(
+  wget_error_code=""
+  {
     {
-      {
-	wget --ca-certificate=/etc/puavo/certs/rootca.pem \
-	     --continue                                   \
-	     --output-document="${output_path}"           \
-	     --progress=dot:mega                          \
-	     $wgetopts                                    \
-	     "$url" >/dev/null                            \
-	  || echo $?
-      } 3>&1 1>&2 2>&3 3>&- \
-	| unbuffer -p awk '
-	    BEGIN { progress = -1 }
+      wget --ca-certificate=/etc/puavo/certs/rootca.pem \
+	   --continue                                   \
+	   --output-document="${output_path}"           \
+	   --progress=dot:mega                          \
+	   $wgetopts                                    \
+	   "$url" >/dev/null                            \
+	|| wget_error_code=$?
+    } 2>&1 \
+      | unbuffer -p awk '
+	  BEGIN { progress = -1 }
 
-	    {
-	      if (match($8, /^([[:digit:]]+)%$/, a)) {
-		new_progress = a[1]
-		if (progress != new_progress) {
-		  progress = new_progress
-		  print progress
-		}
+	  {
+	    if (match($8, /^([[:digit:]]+)%$/, a)) {
+	      new_progress = a[1]
+	      if (progress != new_progress) {
+		progress = new_progress
+		print progress
 	      }
 	    }
-	  ' 2>/dev/null \
-	| update_stats_with_progress "$phase"
-    } 2>&1 || true
-  )
+	  }
+	' 2>/dev/null \
+      | update_stats_with_progress "$phase"
+  } || true
 
   if [ -n "$wget_error_code" ]; then
     log err "fetching $url, wget error code $wget_error_code"
@@ -731,32 +730,34 @@ try_full_image_update_from_imageserver() {
   rsyncserver="$(echo "$image_server" | cut -d: -f1)"
   remote_rsyncpath="${rsyncserver}::images/${next_image}"
 
-  rsync_error_code=$(
+  # XXX Using --fuzzy might be nice... currently we do not benefit from rsync,
+  # XXX and we should be able to.
+
+  rsync_error_code=""
+  {
     {
-      {
-	rsync --append                          \
-	      --fuzzy                           \
-	      --partial                         \
-	      $rsyncopts                        \
-	      "$remote_rsyncpath"               \
-	      "${images_dir}/${next_image}.tmp" \
-	  || echo $?
-      } 3>&1 1>&2 2>&3 3>&- \
-	| unbuffer -p awk '
-            BEGIN { progress = -1 }
-            {
-              if (match($2, /^([[:digit:]]+)%$/, a)) {
-                new_progress = a[1]
-                if (progress != new_progress) {
-                  progress = new_progress
-                  print progress
-                }
-              }
-            }
-	  ' 2>/dev/null \
-	| update_stats_with_progress image_download
-    } 2>&1 || true
-  )
+      rsync --append                          \
+	    --partial                         \
+	    --progress                        \
+	    $rsyncopts                        \
+	    "$remote_rsyncpath"               \
+	    "${images_dir}/${next_image}.tmp" \
+          2>/dev/null                         \
+	|| rsync_error_code=$?
+    } | unbuffer -p awk '
+	  BEGIN { progress = -1 }
+	  {
+	    if (match($2, /^([[:digit:]]+)%$/, a)) {
+	      new_progress = a[1]
+	      if (progress != new_progress) {
+		progress = new_progress
+		print progress
+	      }
+	    }
+	  }
+	' \
+      | update_stats_with_progress image_download
+  } || true
 
   if [ -z "$rsync_error_code" ]; then
     log info "rsync fetched the image $next_image with success"

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -732,7 +732,7 @@ try_full_image_update_from_imageserver() {
   remote_rsyncpath="${rsyncserver}::images/${next_image}"
 
   # rsync may take a little while before it outputs progress information
-  echo 0 | update_stats_with_progress image_download
+  echo 0 | update_stats_with_progress image_sync
 
   rsync_error_code=$(
     {
@@ -758,7 +758,7 @@ try_full_image_update_from_imageserver() {
 	      }
 	    }
 	  ' \
-	| update_stats_with_progress image_download
+	| update_stats_with_progress image_sync
     } 2>&1 || true
   )
 
@@ -860,6 +860,7 @@ update_stats_with_progress() {
   #   rdiff_checksum
   #   image_patch
   #   image_download
+  #   image_sync
   #   image_checksum
   #   finished
   #   uptodate

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -329,32 +329,33 @@ fetch_with_wget() {
     wgetopts="--limit-rate=$rate_limit"
   fi
 
-  wget_error_code=""
-  {
+  wget_error_code=$(
     {
-      wget --ca-certificate=/etc/puavo/certs/rootca.pem \
-	   --continue                                   \
-	   --output-document="${output_path}"           \
-	   --progress=dot:mega                          \
-	   $wgetopts                                    \
-	   "$url" >/dev/null                            \
-	|| wget_error_code=$?
-    } 2>&1 \
-      | unbuffer -p awk '
-	  BEGIN { progress = -1 }
+      {
+	wget --ca-certificate=/etc/puavo/certs/rootca.pem \
+	     --continue                                   \
+	     --output-document="${output_path}"           \
+	     --progress=dot:mega                          \
+	     $wgetopts                                    \
+	     "$url" >/dev/null                            \
+	  || echo $?
+      } 3>&1 1>&2 2>&3 3>&- \
+	| unbuffer -p awk '
+	    BEGIN { progress = -1 }
 
-	  {
-	    if (match($8, /^([[:digit:]]+)%$/, a)) {
-	      new_progress = a[1]
-	      if (progress != new_progress) {
-		progress = new_progress
-		print progress
+	    {
+	      if (match($8, /^([[:digit:]]+)%$/, a)) {
+		new_progress = a[1]
+		if (progress != new_progress) {
+		  progress = new_progress
+		  print progress
+		}
 	      }
 	    }
-	  }
-	' 2>/dev/null \
-      | update_stats_with_progress "$phase"
-  } || true
+	  ' 2>/dev/null \
+	| update_stats_with_progress "$phase"
+    } 2>&1 || true
+  )
 
   if [ -n "$wget_error_code" ]; then
     log err "fetching $url, wget error code $wget_error_code"

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -238,7 +238,8 @@ cksum_with_progress() {
 
 cleanup_previous_runs() {
   rdiffs_dir=$1
-  preserve_filename=$2
+  preserve_imagefile=$2
+  preserve_rdifffile=$3
 
   old_imageoverlays=$(
     "${puavoinstall_libdir}/ls-old-imageoverlays" "${images_dir}" \
@@ -257,18 +258,23 @@ cleanup_previous_runs() {
   old_images=$("${puavoinstall_libdir}/ls-old-images" "${images_dir}")
   if [ -n "${old_images}" ]; then
     echo -n "${old_images}" \
-      | grep -vx "${images_dir}/${preserve_filename}" \
+      | fgrep -vx "${images_dir}/${preserve_imagefile}" \
       | xargs -r -d'\n' -L1 rm -f
   fi
 
   # cleanup old rdiff files, except those that we want to use right now
   if [ -d "$rdiffs_dir" ]; then
-    find "$rdiffs_dir" -maxdepth 1 -type f -a \
-      '(' '(' -name '*.rdiff' -o -name '*.rdiff.tmp' ')' \
-	  -a '!' '('    -name "${preserve_filename}" \
-		     -o -name "${preserve_filename}.tmp" ')' ')' \
-      -print0 \
-    | xargs -0 rm -f
+    if [ -z "$preserve_rdifffile" ]; then
+      find "$rdiffs_dir" -maxdepth 1 \
+             -type f -a '(' -name '*.rdiff' -o -name '*.rdiff.tmp' ')' -print0
+    else
+      find "$rdiffs_dir" -maxdepth 1                                     \
+             -type f -a '('                                              \
+               '(' -name '*.rdiff' -o -name '*.rdiff.tmp' ')'            \
+	          -a '!' '('   -name "${preserve_rdifffile}"             \
+		            -o -name "${preserve_rdifffile}.tmp" ')' ')' \
+        -print0
+    fi | xargs -0 rm -f
   fi
 }
 
@@ -396,7 +402,7 @@ get_next_image() {
 
   mkdir -p "$rdiffs_dir"
 
-  cleanup_previous_runs "$rdiffs_dir" "$rdiff_filename"
+  cleanup_previous_runs "$rdiffs_dir" "${next_image}.tmp" "$rdiff_filename"
 
   ensure_enough_available_diskspace "$rdiffs_dir"
 
@@ -491,12 +497,12 @@ install_from_file_or_nbd() {
   case "$type_opt" in
     -file)
       image_src_path=$type_arg
-      preserve_filename=$(basename "$image_src_path")
+      preserve_imagefile=$(basename "$image_src_path")
       total_size=$(du -k "$image_src_path" | awk '{ print $1 "k" }')
       ;;
     -nbd)
       image_src_path=$type_arg
-      preserve_filename=''
+      preserve_imagefile=''
       total_size=$(df "$image_src_path" \
 		     | awk -v image_src_path="$image_src_path" '
 			 $1 == image_src_path { print $2 "k" }
@@ -508,7 +514,7 @@ install_from_file_or_nbd() {
       ;;
   esac
 
-  cleanup_previous_runs "${images_dir}/rdiffs" "$preserve_filename"
+  cleanup_previous_runs "${images_dir}/rdiffs" "$preserve_imagefile" ''
 
   dd "if=$image_src_path" 2>/dev/null | pv -s "$total_size" \
     > "${imagepath}.tmp"

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -680,8 +680,7 @@ try_full_image_update_from_imageserver() {
   next_image=$3
 
   checksums_file=$(
-    get_checksums_file "$rate_limit" \
-		       "https://${image_server}/rdiffs/CKSUMS") \
+    get_checksums_file "$rate_limit" "https://${image_server}/CKSUMS") \
       || return 1
 
   next_image_tmppath="${images_dir}/${next_image}.tmp"
@@ -750,8 +749,7 @@ try_rdiff_update_from_imageserver() {
   next_image=$6
 
   checksums_file=$(
-    get_checksums_file "$rate_limit" \
-		       "https://${image_server}/rdiffs/CKSUMS") \
+    get_checksums_file "$rate_limit" "https://${image_server}/CKSUMS") \
       || return 1
 
   rdiff_url="https://${image_server}/rdiffs/${rdiff_filename}"

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -13,17 +13,27 @@ flock -nx 3 || { echo did not get a lock, exiting; exit 1; }
 set -eu
 
 log() {
-    case "$1" in
-      warn|err|crit|alert|emerg)
-        logger_flags="-s"
-        ;;
-      *)
-        if $quiet; then return 0; fi
-        logger_flags=""
-        ;;
-    esac
-    echo "$2" \
-      | logger -p "$1" $logger_flags -t puavo-install-and-update-ltspimages
+  log_to_stdout=false
+  log_to_stderr=false
+
+  logpriority=$1
+  logmessage=$2
+
+  case "$logpriority" in
+    warn|err|crit|alert|emerg)
+      log_to_stderr=true
+      ;;
+    *)
+      $quiet && return 0
+      log_to_stdout=true
+      ;;
+  esac
+
+  $log_to_stdout && echo "$logmessage"
+  $log_to_stderr && echo "$logmessage" >&2
+
+  echo "$logmessage" \
+    | logger -p "$logpriority" -t puavo-install-and-update-ltspimages
 }
 
 usage() {

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -48,7 +48,7 @@ puavoinstall_libdir=/usr/lib/puavo-ltsp-install
 hosttype=""
 image_from_file=""
 image_from_nbd=""
-rate_limit_opts=""
+rate_limit=""
 quiet=false
 delete_overlays=false
 run_preinst_hook=true
@@ -75,7 +75,9 @@ while [ $# -ne 0 ]; do
       image_from_nbd="$2"; shift; shift
       ;;
     -r|--rate-limit)
-      rate_limit_opts="--limit-rate=$2"; shift; shift
+      # NOTE: acceptable rate limit parameters must be something that both
+      #       rsync (--bwlimit) and wget (--limit-rate) understand
+      rate_limit="$2"; shift; shift
       ;;
     -q|--quiet)
       quiet=true; shift;
@@ -280,10 +282,15 @@ ensure_that_default_image_is_the_current_one() {
 }
 
 fetch_with_wget() {
-  extra_wget_opts=$1
+  rate_limit=$1
   output_path=$2  
   url=$3
   phase=$4
+
+  wgetopts=""
+  if [ -n "$rate_limit" ]; then
+    wgetopts="--limit-rate=$rate_limit"
+  fi
 
   wget_error_code=$(
     {
@@ -292,7 +299,7 @@ fetch_with_wget() {
 	     --continue                                   \
 	     --output-document=${output_path}             \
 	     --progress=dot                               \
-             $extra_wget_opts                             \
+             "$wgetopts"                                  \
 	     "$url" >/dev/null                            \
 	  || echo $?
       } 3>&1 1>&2 2>&3 3>&- \
@@ -323,12 +330,12 @@ fetch_with_wget() {
 }
 
 get_checksums_file() {
-  extra_wget_opts=$1
+  rate_limit=$1
   url=$2
 
   checksum_file_path="${images_dir}/CKSUMS"
 
-  fetch_with_wget "$extra_wget_opts"          \
+  fetch_with_wget "$rate_limit"               \
 		  "${checksum_file_path}.tmp" \
 		  "$url"                      \
                   checksums_fetch             \
@@ -340,7 +347,7 @@ get_checksums_file() {
 
 get_next_image() {
   next_image=$1
-  rate_limit_opts=$2
+  rate_limit=$2
 
   image_server_list=$(lookup_image_servers)
 
@@ -366,7 +373,7 @@ get_next_image() {
 
   for image_server in $image_server_list; do
     try_rdiff_update_from_imageserver "$image_server"    \
-				      "$rate_limit_opts" \
+				      "$rate_limit"      \
 				      "$rdiff_filename"  \
 				      "$rdiffs_dir"      \
 				      "$previous_image"  \
@@ -378,16 +385,50 @@ get_next_image() {
   # servers in $image_server_list.
 
   for image_server in $image_server_list; do
-    # XXX to be done
-    false && return 0
+    try_full_image_update_from_imageserver "$image_server" \
+					   "$rate_limit"   \
+				           "$next_image"   \
+      && return 0
   done
 
   return 1
 }
 
+try_full_image_update_from_imageserver() {
+  image_server=$1
+  rate_limit=$2
+  next_image=$3
+
+  checksums_file=$(
+    get_checksums_file "$rate_limit" \
+		       "https://${image_server}/rdiffs/CKSUMS") \
+      || return 1
+
+  next_image_tmppath="${images_dir}/${next_image}.tmp"
+
+  rsyncopts=""
+  if [ -n "$rate_limit" ]; then
+    rsyncopts="--bwlimit=$rate_limit"
+  fi
+
+  # XXX how to output progress data?
+
+  rsync --append                                \
+        --partial                               \
+        "$rsyncopts"                            \
+        "${image_server}::images/${next_image}" \
+        "${images_dir}/${next_image}.tmp"       \
+    || return 1
+
+  check_image_and_put_it_to_use "$next_image"         \
+                                "$next_image_tmppath" \
+                                "$checksums_file"     \
+    || return 1
+}
+
 get_rdiff() {
   rdiffs_dir=$1
-  extra_wget_opts=$2
+  rate_limit=$2
   rdiff_filename=$3
   rdiff_url=$4
   checksums_file=$5
@@ -402,7 +443,7 @@ get_rdiff() {
   log info "we are missing the full rdiff $rdiff_filename, going to get it"
 
   rdiff_tmp="${rdiff_path}.tmp"
-  fetch_with_wget "$extra_wget_opts" "$rdiff_tmp" "$rdiff_url" rdiff_fetch \
+  fetch_with_wget "$rate_limit" "$rdiff_tmp" "$rdiff_url" rdiff_fetch \
     || return 1
   check_with_cksum "$rdiff_filename" \
                    "$rdiff_tmp"      \
@@ -662,21 +703,21 @@ set_image_as_default_image() {
 
 try_rdiff_update_from_imageserver() {
   image_server=$1
-  rate_limit_opts=$2
+  rate_limit=$2
   rdiff_filename=$3
   rdiffs_dir=$4
   previous_image=$5
   next_image=$6
 
   checksums_file=$(
-    get_checksums_file "$rate_limit_opts" \
+    get_checksums_file "$rate_limit" \
 		       "https://${image_server}/rdiffs/CKSUMS") \
       || return 1
 
   rdiff_url="https://${image_server}/rdiffs/${rdiff_filename}"
 
   get_rdiff "$rdiffs_dir"      \
-	    "$rate_limit_opts" \
+	    "$rate_limit"      \
 	    "$rdiff_filename"  \
 	    "$rdiff_url"       \
 	    "$checksums_file"  \
@@ -692,13 +733,13 @@ try_rdiff_update_from_imageserver() {
 
 update_image() {
   next_image=$1
-  rate_limit_opts=$2
+  rate_limit=$2
 
   if [ ! -e "${images_dir}/${next_image}" ]; then
     ensure_that_default_image_is_the_current_one
 
     log info "we are missing $next_image, going to get it"
-    get_next_image "$next_image" "$rate_limit_opts"
+    get_next_image "$next_image" "$rate_limit"
   fi
 
   # must call /usr/bin/test because /bin/sh is broken regarding this test
@@ -763,7 +804,7 @@ if [ -n "$image_from_file" ]; then
 elif [ -n "$image_from_nbd" ]; then
   install_image "$next_image" -nbd  "$image_from_nbd"
 else
-  update_image "$next_image" "$rate_limit_opts"
+  update_image "$next_image" "$rate_limit"
 fi
 
 exit 0

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -686,15 +686,18 @@ try_full_image_update_from_imageserver() {
     rsyncopts="--bwlimit=$rate_limit"
   fi
 
-  remotepath="${image_server}::images/${next_image}"
+  # The possible port number in $image_server is for https only
+  rsyncserver="$(echo "$image_server" | cut -d: -f1)"
+  remote_rsyncpath="${rsyncserver}::images/${next_image}"
 
   rsync_error_code=$(
     {
       {
 	rsync --append                          \
+	      --fuzzy                           \
 	      --partial                         \
 	      "$rsyncopts"                      \
-	      "$remotepath"                     \
+	      "$remote_rsyncpath"               \
 	      "${images_dir}/${next_image}.tmp" \
 	  || echo $?
       } 3>&1 1>&2 2>&3 3>&- \
@@ -714,12 +717,18 @@ try_full_image_update_from_imageserver() {
     } 2>&1 || true
   )
 
-  if [ -n "$rsync_error_code" ]; then
-    log err "error in syncing ${remotepath}: rsync returned $rsync_error_code"
-    return 1
+  if [ -z "$rsync_error_code" ]; then
+    log info "rsync fetched the image $next_image with success"
+  else
+    log err "error in rsyncing ${remote_rsyncpath}: $rsync_error_code"
+    httpurl="https://${image_server}/${next_image}"
+    log info "falling back to fetching $httpurl"
+    fetch_with_wget "$rate_limit"         \
+		    "$next_image_tmppath" \
+		    "$httpurl"            \
+		    image_download        \
+      || return 1
   fi
-
-  log info "rsync fetched the image $next_image with success"
 
   check_image_and_put_it_to_use "$next_image"         \
                                 "$next_image_tmppath" \

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -394,38 +394,6 @@ get_next_image() {
   return 1
 }
 
-try_full_image_update_from_imageserver() {
-  image_server=$1
-  rate_limit=$2
-  next_image=$3
-
-  checksums_file=$(
-    get_checksums_file "$rate_limit" \
-		       "https://${image_server}/rdiffs/CKSUMS") \
-      || return 1
-
-  next_image_tmppath="${images_dir}/${next_image}.tmp"
-
-  rsyncopts=""
-  if [ -n "$rate_limit" ]; then
-    rsyncopts="--bwlimit=$rate_limit"
-  fi
-
-  # XXX how to output progress data?
-
-  rsync --append                                \
-        --partial                               \
-        "$rsyncopts"                            \
-        "${image_server}::images/${next_image}" \
-        "${images_dir}/${next_image}.tmp"       \
-    || return 1
-
-  check_image_and_put_it_to_use "$next_image"         \
-                                "$next_image_tmppath" \
-                                "$checksums_file"     \
-    || return 1
-}
-
 get_rdiff() {
   rdiffs_dir=$1
   rate_limit=$2
@@ -701,6 +669,64 @@ set_image_as_default_image() {
   update_stats finished 100
 }
 
+try_full_image_update_from_imageserver() {
+  image_server=$1
+  rate_limit=$2
+  next_image=$3
+
+  checksums_file=$(
+    get_checksums_file "$rate_limit" \
+		       "https://${image_server}/rdiffs/CKSUMS") \
+      || return 1
+
+  next_image_tmppath="${images_dir}/${next_image}.tmp"
+
+  rsyncopts=""
+  if [ -n "$rate_limit" ]; then
+    rsyncopts="--bwlimit=$rate_limit"
+  fi
+
+  remotepath="${image_server}::images/${next_image}"
+
+  rsync_error_code=$(
+    {
+      {
+	rsync --append                          \
+	      --partial                         \
+	      "$rsyncopts"                      \
+	      "$remotepath"                     \
+	      "${images_dir}/${next_image}.tmp" \
+	  || echo $?
+      } 3>&1 1>&2 2>&3 3>&- \
+	| unbuffer -p awk '
+            BEGIN { progress = -1 }
+            {
+              if (match($2, /^([[:digit:]]+)%$/, a)) {
+                new_progress = a[1]
+                if (progress != new_progress) {
+                  progress = new_progress
+                  print progress
+                }
+              }
+            }
+	  ' 2>/dev/null \
+	| update_stats_with_progress image_download
+    } 2>&1 || true
+  )
+
+  if [ -n "$rsync_error_code" ]; then
+    log err "error in syncing ${remotepath}: rsync returned $rsync_error_code"
+    return 1
+  fi
+
+  log info "rsync fetched the image $next_image with success"
+
+  check_image_and_put_it_to_use "$next_image"         \
+                                "$next_image_tmppath" \
+                                "$checksums_file"     \
+    || return 1
+}
+
 try_rdiff_update_from_imageserver() {
   image_server=$1
   rate_limit=$2
@@ -776,6 +802,7 @@ update_stats_with_progress() {
   #   rdiff_fetch
   #   rdiff_checksum
   #   image_patch
+  #   image_download
   #   image_checksum
   #   finished
   #   uptodate

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -244,21 +244,21 @@ cleanup_previous_runs() {
     "${puavoinstall_libdir}/ls-old-imageoverlays" "${images_dir}" \
 						  /imageoverlays)
   if [ -n "${old_imageoverlays}" ]; then
-      if ${delete_overlays}; then
-          echo -n "${old_imageoverlays}" | xargs -r -d'\n' -L1 rm -rf
-      else
-          log err "cleanup failed: old images have existing overlays and --delete-overlays was not used" >&2
-          return 1
-      fi
+    if ${delete_overlays}; then
+      echo -n "${old_imageoverlays}" | xargs -r -d'\n' -L1 rm -rf
+    else
+      log err "cleanup failed: old images have existing overlays and --delete-overlays was not used" >&2
+      return 1
+    fi
   fi
 
   # cleanup old ltsp images (and their possible temporary *.tmp files).
   # The ltsp-backup.img is going to go too...
   old_images=$("${puavoinstall_libdir}/ls-old-images" "${images_dir}")
   if [ -n "${old_images}" ]; then
-      echo -n "${old_images}" \
-        | grep -vx "${images_dir}/${preserve_filename}" \
-        | xargs -r -d'\n' -L1 rm -f
+    echo -n "${old_images}" \
+      | grep -vx "${images_dir}/${preserve_filename}" \
+      | xargs -r -d'\n' -L1 rm -f
   fi
 
   # cleanup old rdiff files, except those that we want to use right now

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -335,8 +335,8 @@ fetch_with_wget() {
 	wget --ca-certificate=/etc/puavo/certs/rootca.pem \
 	     --continue                                   \
 	     --output-document="${output_path}"           \
-	     --progress=dot                               \
-             $wgetopts                                    \
+	     --progress=dot:mega                          \
+	     $wgetopts                                    \
 	     "$url" >/dev/null                            \
 	  || echo $?
       } 3>&1 1>&2 2>&3 3>&- \
@@ -344,7 +344,7 @@ fetch_with_wget() {
 	    BEGIN { progress = -1 }
 
 	    {
-	      if (match($7, /^([[:digit:]]+)%$/, a)) {
+	      if (match($8, /^([[:digit:]]+)%$/, a)) {
 		new_progress = a[1]
 		if (progress != new_progress) {
 		  progress = new_progress

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -731,34 +731,36 @@ try_full_image_update_from_imageserver() {
   rsyncserver="$(echo "$image_server" | cut -d: -f1)"
   remote_rsyncpath="${rsyncserver}::images/${next_image}"
 
-  # XXX Using --fuzzy might be nice... currently we do not benefit from rsync,
-  # XXX and we should be able to.
+  # rsync may take a little while before it outputs progress information
+  echo 0 | update_stats_with_progress image_download
 
-  rsync_error_code=""
-  {
+  rsync_error_code=$(
     {
-      rsync --append                          \
-	    --partial                         \
-	    --progress                        \
-	    $rsyncopts                        \
-	    "$remote_rsyncpath"               \
-	    "${images_dir}/${next_image}.tmp" \
-          2>/dev/null                         \
-	|| rsync_error_code=$?
-    } | unbuffer -p awk '
-	  BEGIN { progress = -1 }
-	  {
-	    if (match($2, /^([[:digit:]]+)%$/, a)) {
-	      new_progress = a[1]
-	      if (progress != new_progress) {
-		progress = new_progress
-		print progress
+      {
+	rsync --fuzzy                           \
+	      --inplace                         \
+	      --progress                        \
+	      $rsyncopts                        \
+	      "$remote_rsyncpath"               \
+	      "${images_dir}/${next_image}.tmp" \
+	    2>/dev/null                         \
+	  || echo $? >&2
+      } | unbuffer -p awk '
+	    BEGIN { progress = -1 }
+
+	    {
+	      if (match($2, /^([[:digit:]]+)%$/, a)) {
+		new_progress = a[1]
+		if (progress != new_progress) {
+		  progress = new_progress
+		  print progress
+		}
 	      }
 	    }
-	  }
-	' \
-      | update_stats_with_progress image_download
-  } || true
+	  ' \
+	| update_stats_with_progress image_download
+    } 2>&1 || true
+  )
 
   if [ -z "$rsync_error_code" ]; then
     log info "rsync fetched the image $next_image with success"

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -27,12 +27,14 @@ log() {
 }
 
 usage() {
-  {
-    echo "Usage:"
-    echo "  $(basename $0) [--quiet] [--delete-overlays] [--install-from-file path] next_ltsp_image_name"
-    echo "  $(basename $0) [--quiet] [--delete-overlays] [--install-from-nbd path]  next_ltsp_image_name"
-    echo "  $(basename $0) [--quiet] [--delete-overlays] [--rate-limit rate]        next_ltsp_image_name"
-  } > /dev/stderr
+  cat <<EOF > /dev/stderr
+Usage:
+  $(basename $0) [--quiet] [--delete-overlays] [--install-from-file path] next_ltsp_image_name"
+  $(basename $0) [--quiet] [--delete-overlays] [--install-from-nbd path]  next_ltsp_image_name"
+  $(basename $0) [--quiet] [--delete-overlays] [--rate-limit rate]        next_ltsp_image_name"
+
+  -r / --rate-limit must match regexp [0-9]+[km] for kilobytes/megabytes per second
+EOF
   exit 1
 }
 
@@ -75,9 +77,13 @@ while [ $# -ne 0 ]; do
       image_from_nbd="$2"; shift; shift
       ;;
     -r|--rate-limit)
-      # NOTE: acceptable rate limit parameters must be something that both
-      #       rsync (--bwlimit) and wget (--limit-rate) understand
+      # Acceptable rate limit parameters must be something that both
+      # rsync (--bwlimit) and wget (--limit-rate) understand.
       rate_limit="$2"; shift; shift
+      if ! echo "$rate_limit" | grep -Eqx '[0-9]+[km]'; then
+        log err "The rate limit was not understood, got '$rate_limit'"
+        usage
+      fi
       ;;
     -q|--quiet)
       quiet=true; shift;
@@ -297,9 +303,9 @@ fetch_with_wget() {
       {
 	wget --ca-certificate=/etc/puavo/certs/rootca.pem \
 	     --continue                                   \
-	     --output-document=${output_path}             \
+	     --output-document="${output_path}"           \
 	     --progress=dot                               \
-             "$wgetopts"                                  \
+             $wgetopts                                    \
 	     "$url" >/dev/null                            \
 	  || echo $?
       } 3>&1 1>&2 2>&3 3>&- \
@@ -695,7 +701,7 @@ try_full_image_update_from_imageserver() {
 	rsync --append                          \
 	      --fuzzy                           \
 	      --partial                         \
-	      "$rsyncopts"                      \
+	      $rsyncopts                        \
 	      "$remote_rsyncpath"               \
 	      "${images_dir}/${next_image}.tmp" \
 	  || echo $?

--- a/puavo-install/puavo-install-grub
+++ b/puavo-install/puavo-install-grub
@@ -196,8 +196,8 @@ if [ -z "$hosttype" ]; then
 fi
 
 # pvs and assorted utilities complain if we leak file descriptors, that is
-# why we do "3>&- 4>&- 5>&- 6>&-" (same with grub-install)
-diskdev=$(pvs 3>&- 4>&- 5>&- 6>&-                                       \
+# why we do "3>&- 4>&- 5>&-" (same with grub-install)
+diskdev=$(pvs 3>&- 4>&- 5>&-                                            \
             | awk -v vgname="$vgname" '$2 == vgname { print $1; exit }' \
             | sed -E 's|[0-9]+$||')
 
@@ -229,7 +229,7 @@ esac
 
 if ! $only_update_config; then
   if ! grub_msg=$(grub-install --root-directory=$images_dir "$diskdev" \
-                    3>&- 4>&- 5>&- 6>&- 2>&1); then
+                    3>&- 4>&- 5>&- 2>&1); then
     echo "Grub installation failed: $grub_msg" >&2
     exit 1
   fi

--- a/puavo-install/puavo-install-grub
+++ b/puavo-install/puavo-install-grub
@@ -196,8 +196,8 @@ if [ -z "$hosttype" ]; then
 fi
 
 # pvs and assorted utilities complain if we leak file descriptors, that is
-# why we do "3>&- 4>&-" (same with grub-install)
-diskdev=$(pvs 3>&- 4>&-                                                 \
+# why we do "3>&- 4>&- 5>&- 6>&-" (same with grub-install)
+diskdev=$(pvs 3>&- 4>&- 5>&- 6>&-                                       \
             | awk -v vgname="$vgname" '$2 == vgname { print $1; exit }' \
             | sed -E 's|[0-9]+$||')
 
@@ -229,7 +229,7 @@ esac
 
 if ! $only_update_config; then
   if ! grub_msg=$(grub-install --root-directory=$images_dir "$diskdev" \
-                    3>&- 4>&- 2>&1); then
+                    3>&- 4>&- 5>&- 6>&- 2>&1); then
     echo "Grub installation failed: $grub_msg" >&2
     exit 1
   fi

--- a/puavo-install/puavo-make-install-disk
+++ b/puavo-install/puavo-make-install-disk
@@ -41,7 +41,7 @@ install_image $install_args
 umount "$images_dir"
 dmsetup remove puavoinstaller-installimages
 
-# do not leak file descriptors to vgchange, hence "3>&- 4>&-"
-vgchange -a n puavoinstaller 3>&- 4>&-
+# do not leak file descriptors to vgchange, hence "3>&- 4>&- 5>&- 6>&-"
+vgchange -a n puavoinstaller 3>&- 4>&- 5>&- 6>&-
 
 rmdir /installimages

--- a/puavo-install/puavo-make-install-disk
+++ b/puavo-install/puavo-make-install-disk
@@ -41,7 +41,7 @@ install_image $install_args
 umount "$images_dir"
 dmsetup remove puavoinstaller-installimages
 
-# do not leak file descriptors to vgchange, hence "3>&- 4>&- 5>&- 6>&-"
-vgchange -a n puavoinstaller 3>&- 4>&- 5>&- 6>&-
+# do not leak file descriptors to vgchange, hence "3>&- 4>&- 5>&-"
+vgchange -a n puavoinstaller 3>&- 4>&- 5>&-
 
 rmdir /installimages

--- a/puavo-install/puavo-update-client
+++ b/puavo-install/puavo-update-client
@@ -79,7 +79,7 @@ dbus_cmd="
 
 if ! $do_image_update; then
     # do only the configuration update
-    if $dbus_cmd org.puavo.client.update.UpdateConfiguration; then
+    if $dbus_cmd org.puavo.client.update.UpdateConfiguration >/dev/null; then
         echo 'Configuration update started.'
     else
         echo 'Starting configuration update failed.' >&2
@@ -89,7 +89,7 @@ else
     # do the whole update (configuration update + image update)
     if $dbus_cmd org.puavo.client.update.Update \
                  "boolean:${use_rate_limit}"    \
-                 "boolean:${delete_overlays}"; then
+                 "boolean:${delete_overlays}" >/dev/null; then
         echo 'System update started.'
     else
         echo 'Starting system update failed.' >&2

--- a/puavo-install/puavo-update-client
+++ b/puavo-install/puavo-update-client
@@ -79,10 +79,20 @@ dbus_cmd="
 
 if ! $do_image_update; then
     # do only the configuration update
-    $dbus_cmd org.puavo.client.update.UpdateConfiguration
+    if $dbus_cmd org.puavo.client.update.UpdateConfiguration; then
+        echo 'Configuration update started.'
+    else
+        echo 'Starting configuration update failed.' >&2
+        exit 1
+    fi
 else
     # do the whole update (configuration update + image update)
-    $dbus_cmd org.puavo.client.update.Update \
-              "boolean:${use_rate_limit}"    \
-              "boolean:${delete_overlays}"
+    if $dbus_cmd org.puavo.client.update.Update \
+                 "boolean:${use_rate_limit}"    \
+                 "boolean:${delete_overlays}"; then
+        echo 'System update started.'
+    else
+        echo 'Starting system update failed.' >&2
+        exit 1
+    fi
 fi

--- a/tools/image-build/puavo-build-image
+++ b/tools/image-build/puavo-build-image
@@ -228,9 +228,9 @@ def output_makefile(builder_confs, config_files)
   puts <<EOF
 IMAGES_DIR        = #{ images_dir }
 RDIFFS_DIR        = #{ rdiffs_dir }
-CKSUMS_DIR        = ${RDIFFS_DIR}/.cksums
-MIRROR_DIR        = ${RDIFFS_DIR}/.mirror
-SIGNATURES_DIR    = ${RDIFFS_DIR}/.signatures
+CKSUMS_DIR        = ${IMAGES_DIR}/.cksums
+MIRROR_DIR        = ${IMAGES_DIR}/mirror
+SIGNATURES_DIR    = ${IMAGES_DIR}/.signatures
 RDIFF_TARGET_DIRS = #{ rdiff_target_dirs.join(' ') }
 
 ALL_DIRS = ${CKSUMS_DIR} ${MIRROR_DIR} ${MIRROR_DIR}/rdiffs \\
@@ -238,6 +238,8 @@ ALL_DIRS = ${CKSUMS_DIR} ${MIRROR_DIR} ${MIRROR_DIR}/rdiffs \\
 
 CHROOT_TARGETS = apply-buildrules chroot cleanup-chroot image \\
                  install-packages update-chroot
+
+COMMON_TARGETS = all-new-images all-rdiffs cksums cleanup-mirror update-mirror
 
 IMAGE_FILES = #{ image_files.join(' ') }
 
@@ -266,11 +268,14 @@ help:
 	@echo "Available image series targets are:"
 	@echo "  ${IMAGE_SERIES}" | fmt
 	@echo
-	@echo "Available other targets are:"
+	@echo "Available chroot targets are:"
 	@echo "  ${CHROOT_TARGETS}" | fmt
 	@echo
 	@echo "Available rdiff series targets are:"
 	@echo "  ${IMAGE_SERIES_RDIFF_TARGETS}" | fmt
+	@echo
+	@echo "Available common targets are:"
+	@echo "  ${COMMON_TARGETS}" | fmt
 
 .PHONY: all-new-images
 all-new-images: ${IMAGE_SERIES}
@@ -278,13 +283,19 @@ all-new-images: ${IMAGE_SERIES}
 .PHONY: all-rdiffs
 all-rdiffs: ${RDIFF_FILES_AP}
 
+.PHONY: cksums
+cksums: ${IMAGES_DIR}/CKSUMS
+
 .PHONY: update-mirror
 update-mirror: ${MIRROR_DIR}/CKSUMS ${MIRROR_DIR_IMAGES} ${MIRROR_DIR_RDIFFS}
 
 .PHONY: cleanup-mirror
 cleanup-mirror:
-	@test -d "${MIRROR_DIR}"
-	rm -rf ${MIRROR_DIR}/*
+	@if [ -d "${MIRROR_DIR}" ]; then \
+	  rm -rf ${MIRROR_DIR}/*; \
+	else \
+	  echo There is no mirror directory ${MIRROR_DIR}; \
+	fi
 
 .PHONY: ${CHROOT_TARGETS}
 ${CHROOT_TARGETS}:
@@ -305,8 +316,11 @@ ${CKSUMS_DIR}/%.rdiff.cksum: %.rdiff | ${CKSUMS_DIR}
 	cksum $< > $@.tmp
 	mv $@.tmp $@
 
-${MIRROR_DIR}/CKSUMS: ${CKSUM_FILES_AP} | ${MIRROR_DIR}
+${IMAGES_DIR}/CKSUMS: ${CKSUM_FILES_AP} | ${MIRROR_DIR}
 	awk '{ "basename " $$3 | getline $$3; print }' ${CKSUM_FILES_AP} > $@
+
+${MIRROR_DIR}/CKSUMS: ${IMAGES_DIR}/CKSUMS
+	cp $< $@
 
 # link ${MIRROR_DIR_IMAGES}
 ${MIRROR_DIR}/%.img: %.img | ${MIRROR_DIR}


### PR DESCRIPTION
Lots of changes to local device image updates:

* try multiple image servers
* try various methods: rdiff, rsync and https
   * rdiff is always preferred (all image servers are looked for rdiffs), then, if that does not work out, rsync/https is tried for each server (rsync preferred)
* progress information in applet is hopefully more straightforward and intuitive (0% --> 100%)
* log messages in applet show in more detail what is going on and are chronological(!)
* do not try downloading stuff if their checksums can not be verified anyway
* be helpful and automatically check for image updates when (primary) user logs in (updates device.json)
* progress icon rolls more consistently
* bugfixes

`puavo-install-and-update-ltspimages` probably needs a rewrite in ruby, though.