### PR TITLE
Powersave improvements for laptops

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -286,6 +286,7 @@ install : installdirs $(install-subdirs)
 		puavo-monitor-nbd-connection \
 		puavo-run-xrandr \
 		puavo-thin-guest-account \
+		udev/udev-disable-wifi-powersave \
 		udev/udev-hotplug-monitor \
 		udev/udev-jetpipe \
 		xinitrc

--- a/client/init-puavo.d/91-backlight
+++ b/client/init-puavo.d/91-backlight
@@ -1,11 +1,28 @@
-#!/bin/sh
+has_device_tag () {
+  jq -r .tags[] /etc/puavo/device.json | grep -qx "$1"
+}
 
-BACKLIGHT=$(jq -r '.tags[] | select(. == "intel-backlight")' /etc/puavo/device.json)
-NO_BACKLIGHT=$(jq -r '.tags[] | select(. == "no-intel-backlight")' /etc/puavo/device.json)
+intel_backlight=false
 
-DMIDECODE=$(dmidecode)
+if [ -f "/sys/devices/virtual/dmi/id/product_name" ]; then
+  system=$(cat /sys/devices/virtual/dmi/id/product_name)
+else
+  system=$(dmidecode -s system-product-name)
+fi
 
-if [ "${BACKLIGHT}" = "intel-backlight" ]; then
+if [ "${system}" = "Aspire ES1-111" ]; then
+  intel_backlight=true
+fi
+
+if has_device_tag intel-backlight; then
+  intel_backlight=true
+fi
+
+if has_device_tag no-intel-backlight; then
+  intel_backlight=false
+fi
+
+if [ ${intel_backlight} = true ]; then
   cat <<EOF >/usr/share/X11/xorg.conf.d/backlight.conf
 Section "Device"
     Identifier  "Intel Graphics"

--- a/client/init-puavo.d/92-powersave
+++ b/client/init-puavo.d/92-powersave
@@ -22,7 +22,8 @@ else
   system=$(dmidecode -s system-product-name)
 fi
 
-if [ "${system}" = "TravelMate B115-M" -o \
+if [ "${system}" = "Aspire ES1-111" -o \
+     "${system}" = "TravelMate B115-M" -o \
      "${system}" = "HP ProBook 430 G2" \
    ]; then
   disable_nmi=1

--- a/client/init-puavo.d/92-powersave
+++ b/client/init-puavo.d/92-powersave
@@ -51,3 +51,23 @@ fi
 if [ $sata_alpm != 0 ]; then
   echo SATA_ALPM_ENABLE=${sata_alpm} > /etc/pm/config.d/sata_alpm
 fi
+
+# Wireless interface powersave
+
+if has_device_tag no-wifi-powersave; then
+  cat <<EOF >/etc/pm/power.d/wireless
+# Disabled
+EOF
+
+  cat <<EOF >/etc/udev/rules.d/80-wifi-powersave.rules
+KERNEL=="eth*|ath*|wlan*[0-9]|ra*|sta*", SUBSYSTEM=="net", ENV{DEVTYPE}=="wlan", ACTION=="add|change" RUN+="/usr/lib/puavo-ltsp-client/udev-disable-wifi-powersave"
+EOF
+
+  mkdir -p /etc/laptop-mode/conf.d/
+  cat > /etc/laptop-mode/conf.d/wireless-power.conf <<EOF
+CONTROL_WIRELESS_POWER_SAVING="auto"
+
+WIRELESS_AC_POWER_SAVING=0
+WIRELESS_BATT_POWER_SAVING=0
+EOF
+fi

--- a/client/init-puavo.d/92-powersave
+++ b/client/init-puavo.d/92-powersave
@@ -1,0 +1,52 @@
+has_device_tag () {
+  jq -r .tags[] /etc/puavo/device.json | grep -qx "$1"
+}
+
+# NMI watchdog
+
+disable_nmi=0
+enable_nmi=0
+sata_alpm=0
+
+if has_device_tag enable-nmi-watchdog; then
+  enable_nmi=1
+fi
+
+if has_device_tag disable-nmi-watchdog; then
+  disable_nmi=1
+fi
+
+if [ -f "/sys/devices/virtual/dmi/id/product_name" ]; then
+  system=$(cat /sys/devices/virtual/dmi/id/product_name)
+else
+  system=$(dmidecode -s system-product-name)
+fi
+
+if [ "${system}" = "TravelMate B115-M" -o \
+     "${system}" = "HP ProBook 430 G2" \
+   ]; then
+  disable_nmi=1
+  sata_alpm=true
+fi
+
+if [ $enable_nmi != 0 ]; then
+  echo 1 > /proc/sys/kernel/nmi_watchdog
+else
+  if [ $disable_nmi != 0 ]; then
+    echo 0 > /proc/sys/kernel/nmi_watchdog
+  fi
+fi
+
+# SATA link power management
+
+if has_device_tag enable-sata-alpm; then
+  sata_alpm=true
+fi
+
+if has_device_tag disable-sata-alpm; then
+  sata_alpm=false
+fi
+
+if [ $sata_alpm != 0 ]; then
+  echo SATA_ALPM_ENABLE=${sata_alpm} > /etc/pm/config.d/sata_alpm
+fi

--- a/client/udev/udev-disable-wifi-powersave
+++ b/client/udev/udev-disable-wifi-powersave
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ "${DEVTYPE}" = "wlan" ]; then
+  /sbin/iwconfig ${INTERFACE} power off
+fi


### PR DESCRIPTION
Various improvements for laptop power management. These are automatically used for Acer Aspire ES1-111 and Travelmate B115-M and HP Probook 430 G2. May be these should be defaults.

New tags:
* enable-nmi-watchdog - as suggested by powertop
* disable-nmi-watchdog
* enable-sata-alpm - as suggested by powertop
* disable-sata-alpm
* no-wifi-powersave - disable power management on wireless interfaces (iwconfig xxx0 power off)