### PR TITLE
client: If open-session fails with kerberos authentication, try again

### DIFF
--- a/client/pam/open-session
+++ b/client/pam/open-session
@@ -52,7 +52,7 @@ else
                  "$PUAVO_HOSTNAME")
   fi
 
-  if PUAVO_SESSION=$(
+  if -s ${KRB5CCNAME} -a PUAVO_SESSION=$(
       # use a pipe because $formdata contains a password
       echo -n "$formdata" \
         | /usr/sbin/puavo-rest-client --data -      \
@@ -72,10 +72,32 @@ else
       echo "Failed to get session from puavo-rest (error code ${CODE}), reusing old session: ${PUAVO_SESSION}" \
           | logger -t puavo-open-session -p auth.warn
     else
-      echo "Failed to get session from puavo-rest (error code ${CODE}), no old session to reuse" \
-          | logger -t puavo-open-session -p auth.error
+      # If kerberos authentication fails for some reason, try again with
+      # basic auth.
+      echo "Trying basic auth with user credentials from master server"
 
-      exit 97
+      export PUAVO_REST_CLIENT_PASSWORD=$(cat /dev/stdin)
+
+      if [ -n "$PUAVO_REST_CLIENT_PASSWORD" ]; then
+        if PUAVO_SESSION=$(
+          /usr/sbin/puavo-rest-client --data "$formdata"      \
+                                      --max-time 20 \
+                                      --no-dns      \
+                                      --user $PAM_USER    \
+                                      v3/sessions </dev/null 2>/dev/null); then
+
+          echo "Received puavo session using basic auth: ${PUAVO_SESSION}" \
+              | logger -t puavo-open-session -p auth.info
+        else
+          echo "Failed to get session from puavo-rest (error code ${CODE}), no old session to reuse" \
+              | logger -t puavo-open-session -p auth.error
+
+          exit 97
+        fi
+      else
+        echo "Could not read user password from stdin for basic auth and no session to reuse" \
+            | logger -t puavo-open-session -p auth.error
+      fi
     fi
   fi
 fi

--- a/client/pam/open-session
+++ b/client/pam/open-session
@@ -52,43 +52,50 @@ else
                  "$PUAVO_HOSTNAME")
   fi
 
-  if -s ${KRB5CCNAME} -a PUAVO_SESSION=$(
-      # use a pipe because $formdata contains a password
-      echo -n "$formdata" \
-        | /usr/sbin/puavo-rest-client --data -      \
-                                      --max-time 20 \
-                                      --user-krb    \
-                                      v3/sessions 2>/dev/null); then
-    echo "Received puavo session: ${PUAVO_SESSION}" \
-        | logger -t puavo-open-session -p auth.info
+  CODE=0
+  if [ -s "$KRB5CCNAME" ]; then
+    # Try getting session with kerberos ticket.
+    if PUAVO_SESSION=$(
+         # use a pipe because $formdata contains a password
+         echo -n "$formdata" \
+             | /usr/sbin/puavo-rest-client --data -      \
+                                           --max-time 20 \
+                                           --user-krb    \
+                                           v3/sessions 2>/dev/null); then
+      echo "Received puavo session with kerberos ticket: ${PUAVO_SESSION}" \
+          | logger -t puavo-open-session -p auth.info
 
-    echo "${PUAVO_SESSION}" >"${CACHE_FILE}"
-  else
-    CODE=$?
+      echo "${PUAVO_SESSION}" >"${CACHE_FILE}"
+    else
+      CODE=$?
+    fi
+  fi
 
+  if [ "${CODE}" -ne 0 ]; then
     if [ -f "${CACHE_FILE}" -a "${PUAVO_HOSTTYPE}" = "laptop" ]; then
       PUAVO_SESSION=$(cat $CACHE_FILE)
 
-      echo "Failed to get session from puavo-rest (error code ${CODE}), reusing old session: ${PUAVO_SESSION}" \
+      echo "Failed to get session from puavo-rest with kerberos ticket (error code ${CODE}), reusing old session: ${PUAVO_SESSION}" \
           | logger -t puavo-open-session -p auth.warn
     else
-      # If kerberos authentication fails for some reason, try again with
-      # basic auth.
+      # If kerberos authentication fails for some reason and cache does not
+      # exist, try again with basic auth.
       echo "Trying basic auth with user credentials from master server"
 
       export PUAVO_REST_CLIENT_PASSWORD=$(cat /dev/stdin)
 
       if [ -n "$PUAVO_REST_CLIENT_PASSWORD" ]; then
         if PUAVO_SESSION=$(
-          /usr/sbin/puavo-rest-client --data "$formdata"      \
-                                      --max-time 20 \
-                                      --no-dns      \
-                                      --user $PAM_USER    \
+          /usr/sbin/puavo-rest-client --data "$formdata" \
+                                      --max-time 20      \
+                                      --no-dns           \
+                                      --user $PAM_USER   \
                                       v3/sessions </dev/null 2>/dev/null); then
-
           echo "Received puavo session using basic auth: ${PUAVO_SESSION}" \
               | logger -t puavo-open-session -p auth.info
+          echo "${PUAVO_SESSION}" >"${CACHE_FILE}"
         else
+          CODE=$?
           echo "Failed to get session from puavo-rest (error code ${CODE}), no old session to reuse" \
               | logger -t puavo-open-session -p auth.error
 

--- a/client/pam/open-session
+++ b/client/pam/open-session
@@ -52,7 +52,7 @@ else
                  "$PUAVO_HOSTNAME")
   fi
 
-  CODE=0
+  CODE=107
   if [ -s "$KRB5CCNAME" ]; then
     # Try getting session with kerberos ticket.
     if PUAVO_SESSION=$(
@@ -62,9 +62,9 @@ else
                                            --max-time 20 \
                                            --user-krb    \
                                            v3/sessions 2>/dev/null); then
+      CODE=0
       echo "Received puavo session with kerberos ticket: ${PUAVO_SESSION}" \
           | logger -t puavo-open-session -p auth.info
-
       echo "${PUAVO_SESSION}" >"${CACHE_FILE}"
     else
       CODE=$?

--- a/client/pam/open-session
+++ b/client/pam/open-session
@@ -104,13 +104,15 @@ else
       else
         echo "Could not read user password from stdin for basic auth and no session to reuse" \
             | logger -t puavo-open-session -p auth.error
+
+        exit 98
       fi
     fi
   fi
 fi
 
-if [ "x${PUAVO_SESSION}" = "x" ]; then
-  echo "No session information received from ${API_SERVER}" \
+if [ -z "${PUAVO_SESSION}" ]; then
+  echo "No session information received from puavo" \
       | logger -t puavo-open-session -p auth.error
 
   exit 99

--- a/client/templates/etc/pam.d/lightdm-laptop
+++ b/client/templates/etc/pam.d/lightdm-laptop
@@ -42,7 +42,7 @@ auth    sufficient      pam_permit.so
 
 auth    optional        pam_exec.so quiet /usr/lib/puavo-ltsp-client/pam/puavo-local-config-setup
 auth    required        pam_exec.so /usr/lib/puavo-ltsp-client/pam/make-session-dir
-auth    required        pam_exec.so /usr/lib/puavo-ltsp-client/pam/open-session
+auth    required        pam_exec.so expose_authtok /usr/lib/puavo-ltsp-client/pam/open-session
 auth    required        pam_exec.so /usr/lib/puavo-ltsp-client/pam/populate-extrausers
 auth    optional        pam_sss.so use_first_pass
 auth    optional        pam_gnome_keyring.so


### PR DESCRIPTION
with basic auth. This should make the code more robust against network
specific errors.