### PR TITLE
Authentication improvements

### DIFF
--- a/client/puavo-configure-client
+++ b/client/puavo-configure-client
@@ -299,6 +299,7 @@ case @puavo_device_type
     write_config("/etc/idmapd.conf")
     write_config("/etc/ldap/ldap.conf", "laptop")
     write_config("/etc/lightdm/lightdm.conf")
+    write_config("/etc/pam.d/gnome-screensaver", "laptop")
     write_config("/etc/pam.d/lightdm", "laptop")
     write_config("/etc/pam.d/lightdm-autologin", "laptop")
     write_config("/etc/racoon/racoon.conf")

--- a/client/templates/etc/pam.d/gnome-screensaver-laptop
+++ b/client/templates/etc/pam.d/gnome-screensaver-laptop
@@ -1,0 +1,5 @@
+auth	[success=1 default=ignore]	pam_sss.so
+auth	requisite			pam_deny.so
+auth	required			pam_permit.so
+auth	optional			pam_cap.so 
+auth	optional 			pam_gnome_keyring.so

--- a/client/templates/etc/sssd/sssd.conf-laptop
+++ b/client/templates/etc/sssd/sssd.conf-laptop
@@ -49,6 +49,9 @@ dns_discovery_domain=<%= @puavo_domain %>
 krb5_server = kerberos.<%= @puavo_domain %>,<%= @kerberos_master %>
 krb5_realm = <%= @kerberos_realm %>
 krb5_validate = false
+krb5_lifetime = 7d
+krb5_renewable_lifetime = 7d
+krb5_renew_interval = 3d
 #ldap_krb5_init_creds = true
 #ldap_sasl_mech = gssapi
 #ldap_id_use_start_tls = true


### PR DESCRIPTION
Use custom PAM stack for gnome-screensaver so that unlocking the screensaver does not go to pam_krb5 that probably times out. Also renew kerberos tickets when possible.