### PR TITLE
Basil workaround

### DIFF
--- a/bootserver/sbin/puavo-bootserver-sync-images
+++ b/bootserver/sbin/puavo-bootserver-sync-images
@@ -500,8 +500,8 @@ class SyncFileWithMetadata < SyncFile
     uri = URI.parse(url)
 
     http = Net::HTTP.new(uri.host, uri.port)
-    http.ca_file = "/etc/puavo/certs/rootca.pem"
-    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+#    http.ca_file = "/etc/puavo/certs/rootca.pem"
+#    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.use_ssl = true
 
     http.request_get(uri.path) do |response|
@@ -1155,8 +1155,8 @@ module SeriesControl
     uri = URI.parse(source_url)
 
     http = Net::HTTP.new(uri.host, uri.port)
-    http.ca_file = "/etc/puavo/certs/rootca.pem"
-    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+#    http.ca_file = "/etc/puavo/certs/rootca.pem"
+#    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     http.use_ssl = true
 
     series_by_name = {}

--- a/bootserver/sbin/puavo-bootserver-sync-images
+++ b/bootserver/sbin/puavo-bootserver-sync-images
@@ -498,6 +498,8 @@ class SyncFileWithMetadata < SyncFile
   # (appending to an existing file on later download attempts).
   def download_from_url(url)
     uri = URI.parse(url)
+    
+    uri.port=443
 
     http = Net::HTTP.new(uri.host, uri.port)
 #    http.ca_file = "/etc/puavo/certs/rootca.pem"

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -553,7 +553,7 @@ lookup_image_server_by_dns() {
           i = index($8, puavo_domain)
           if (i == 0) { next }
           if ($8 == (substr($8, 0, i-1) puavo_domain)) {
-            printf "https://%s:%s\n", $8, $7
+            printf "%s:%s\n", $8, $7
             exit(0)
           }
       }'

--- a/puavo-install/puavo-install-and-update-ltspimages
+++ b/puavo-install/puavo-install-and-update-ltspimages
@@ -573,6 +573,10 @@ lookup_image_servers() {
   fi
 
   # XXX not used yet, it is unclear if this will ever be?
+  
+  #add images.amxa.ch
+  all_image_servers="$all_image_servers images.amxa.ch "
+  
   image_servers_by_devicejson=$(
     jq -r '.imageservers[]' /etc/puavo/device.json 2>/dev/null || true)
 

--- a/puavo-install/puavo-setup-filesystems
+++ b/puavo-install/puavo-setup-filesystems
@@ -43,7 +43,7 @@ module DiskHandler
     'laptop' => {
       'swap'          => { 'size' => '4G',       'type' => 'swap' },
       'tmp'           => { 'size' => '6G',       'type' => 'ext4' },
-      'images'        => { 'size' => '40G',      'type' => 'ext4' },
+      'images'        => { 'size' => '80G',      'type' => 'ext4' },
       'state'         => { 'size' => '4G',       'type' => 'ext4' },
       'imageoverlays' => { 'size' => '5G',       'type' => 'ext4' },
       'home'          => { 'size' => '100%FREE', 'type' => 'ext4' },


### PR DESCRIPTION
Hi,

this is not meant to put into the code. These commits just show the workarounds to get
 
- downloading images from https://images.amxa.ch to bootserver
- downloading images from bootserver to laptop
- directely downloading images from https://images.amxa.ch to laptop 

- have enough space in laptops image partition  

to work.
